### PR TITLE
Add Member role to View dashboard permission

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.2b3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add Member role to View dashboard permission
+  [gaudenz]
 
 
 1.2b2 (2012-02-09)

--- a/plone/app/upgrade/v42/betas.py
+++ b/plone/app/upgrade/v42/betas.py
@@ -1,5 +1,7 @@
 import logging
 
+from AccessControl.Permission import Permission
+
 from plone.app.upgrade.utils import loadMigrationProfile
 from Products.CMFCore.utils import getToolByName
 
@@ -32,3 +34,20 @@ def to42beta2(context):
     """4.2b1 -> 4.2b2
     """
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v42:to42beta2')
+
+
+def to42beta3_member_dashboard(context):
+    """Add Member role to "Portlets: View dashboard" permission
+    """
+
+    p = 'Portlets: View dashboard'
+    portal = getToolByName(context, 'portal_url').getPortalObject()
+    roles = Permission(p, (), portal).getRoles(default=[])
+    if not "Member" in roles:
+        acquire = isinstance(roles, list) and True or False
+        roles = list(roles)
+        roles.append("Member")
+        portal.manage_permission("Portlets: View dashboard",
+                                 roles,
+                                 acquire,
+                                 )

--- a/plone/app/upgrade/v42/configure.zcml
+++ b/plone/app/upgrade/v42/configure.zcml
@@ -64,5 +64,17 @@
 
     </genericsetup:upgradeSteps>
 
+    <genericsetup:upgradeSteps
+        source="4203"
+        destination="4204"
+        profile="Products.CMFPlone:plone">
+
+      <genericsetup:upgradeStep
+          title="Add Member role to 'Portlets: View dashboard' permission"
+          description=""
+          handler=".betas.to42beta3_member_dashboard"
+          />
+
+    </genericsetup:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
This grants the member role the right to view the dashboard on
upgrades. The dashboard view was previously not protected by it's
own permission.

I added this to the upgrade from plone 3.x to 4.0a1 because the permission was originally added to this version. I'm a bit confused as to why this was not noticed and fixed long time ago. AFAICS all sites upgraded from 3.x had broken dashboard permissions. The dasboard was only accessible to the Manager role. That's the reason why I send this as a pull request because it might be that I just missed something stupid.
