### PR TITLE
While migrating to Plone 4.3, the Default Plone Password Policy is not added???

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,9 @@ Changelog
 - Don't fail on out of date catalog when upgrading syndication for 4.3
   [tomgross]
 
+- Add Default Plone Password Policy to Plone's acl_users.
+  [gbastien]
+
 1.3.4 (2013-08-14)
 ------------------
 

--- a/plone/app/upgrade/v43/configure.zcml
+++ b/plone/app/upgrade/v43/configure.zcml
@@ -149,6 +149,12 @@
             handler=".final.removePersistentKSSMimeTypeImportStep"
             />
 
+        <genericsetup:upgradeStep
+            title="Add default Plone password policy"
+            description=""
+            handler=".final.addDefaultPlonePasswordPolicy"
+            />
+
     </genericsetup:upgradeSteps>
 
 </configure>

--- a/plone/app/upgrade/v43/final.py
+++ b/plone/app/upgrade/v43/final.py
@@ -38,3 +38,9 @@ def upgradeTinyMCEAgain(context):
 
 def removePersistentKSSMimeTypeImportStep(context):
     unregisterSteps(context, import_steps=['kss_mimetype'])
+
+
+def addDefaultPlonePasswordPolicy(context):
+    portal = getToolByName(context, 'portal_url').getPortalObject()
+    from Products.PlonePAS.Extensions.Install import setupPasswordPolicyPlugin
+    setupPasswordPolicyPlugin(portal)


### PR DESCRIPTION
This step adds it if necessary...

Please confirm the password policy was not added, then review/merge/...

Thank you!

Gauthier
