### PR TITLE
Plip10359 security controlpanel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.3.9 (unreleased)
 ------------------
 
+- Update tests after removal of ``allowAnonymousViewAbout`` and
+  ``validate_email`` properties in CMFPlone.
+  [jcerjak]
+
 - Add upgrade step for the security control panel.
   [jcerjak]
 

--- a/plone/app/upgrade/v30/tests.py
+++ b/plone/app/upgrade/v30/tests.py
@@ -87,6 +87,7 @@ from plone.app.upgrade.v30.alphas import migrateLocalroleForm
 from plone.app.upgrade.v30.alphas import reorderUserActions
 from plone.app.upgrade.v30.alphas import updatePASPlugins
 from plone.app.upgrade.v30.alphas import updateConfigletTitles
+from plone.app.upgrade.v30.alphas import updateMemberSecurity
 from plone.app.upgrade.v30.alphas import addCacheForResourceRegistry
 from plone.app.upgrade.v30.alphas import removeTablelessSkin
 from plone.app.upgrade.v30.alphas import addObjectProvidesIndex
@@ -660,6 +661,12 @@ class TestMigrations_v3_0_alpha2(MigrationTest):
             self.assertEqual(self.portal.getProperty('email_charset'), 'utf-8')
 
     def testUpdateMemberSecurity(self):
+        # validate_email was removed in Plone 5, so we need to add it
+        # manually here
+        self.portal.manage_addProperty('validate_email', False, 'boolean')
+
+        updateMemberSecurity(self.portal)
+
         pprop = getToolByName(self.portal, 'portal_properties')
         self.assertEqual(
                 pprop.site_properties.getProperty('allowAnonymousViewAbout'),

--- a/plone/app/upgrade/v30/tests.py
+++ b/plone/app/upgrade/v30/tests.py
@@ -663,12 +663,18 @@ class TestMigrations_v3_0_alpha2(MigrationTest):
 
     def testUpdateMemberSecurity(self):
         # These properties were removed in Plone 5, so we add them
-        # manually here and check if they are properly updated by the
+        # manually here if needed and check if they are properly updated by the
         # updateMemberSecurity upgrade step
         pprop = getToolByName(self.portal, 'portal_properties')
-        self.portal.manage_addProperty('validate_email', False, 'boolean')
-        pprop.site_properties.manage_addProperty(
-            'allowAnonymousViewAbout', True, 'boolean')
+        try:
+            self.portal.manage_addProperty('validate_email', False, 'boolean')
+        except:  # property is already there
+            pass
+        try:
+            pprop.site_properties.manage_addProperty(
+                'allowAnonymousViewAbout', True, 'boolean')
+        except:  # property is already there
+            pass
 
         updateMemberSecurity(self.portal)
 

--- a/plone/app/upgrade/v30/tests.py
+++ b/plone/app/upgrade/v30/tests.py
@@ -661,16 +661,20 @@ class TestMigrations_v3_0_alpha2(MigrationTest):
             self.assertEqual(self.portal.getProperty('email_charset'), 'utf-8')
 
     def testUpdateMemberSecurity(self):
-        # validate_email was removed in Plone 5, so we need to add it
-        # manually here
+        # These properties were removed in Plone 5, so we add them
+        # manually here and check if they are properly updated by the
+        # updateMemberSecurity upgrade step
+        pprop = getToolByName(self.portal, 'portal_properties')
         self.portal.manage_addProperty('validate_email', False, 'boolean')
+        pprop.site_properties.manage_addProperty(
+            'allowAnonymousViewAbout', True, 'boolean')
 
         updateMemberSecurity(self.portal)
 
-        pprop = getToolByName(self.portal, 'portal_properties')
         self.assertEqual(
-                pprop.site_properties.getProperty('allowAnonymousViewAbout'),
-                False)
+            pprop.site_properties.getProperty('allowAnonymousViewAbout'),
+            False
+        )
 
         pmembership = getToolByName(self.portal, 'portal_membership')
         self.assertEqual(pmembership.memberareaCreationFlag, False)


### PR DESCRIPTION
Read security settings from the registry instead of portal properties. This is part of work on the security control panel migration: https://github.com/plone/Products.CMFPlone/issues/216

This should be merged along with https://github.com/plone/Products.CMFPlone/pull/362
