### PR TITLE
Do not run tests not suited for the current Plone version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.3.9 (unreleased)
 ------------------
 
+- Do not run tests not suited for the current Plone version 
+  (implemented for 4.0 and below)
+  [jensens]
+
 - Add upgrade step for the security control panel.
   [jcerjak]
 

--- a/plone/app/upgrade/tests/base.py
+++ b/plone/app/upgrade/tests/base.py
@@ -10,9 +10,9 @@ import transaction
 from zope.site.hooks import setSite
 
 from Testing.ZopeTestCase.sandbox import Sandboxed
+from Products.PloneTestCase.PloneTestCase import PloneTestCase
 from Products.PloneTestCase.layer import PloneSiteLayer
-from Products.PloneTestCase.ptc import PloneTestCase
-from Products.PloneTestCase.ptc import setupPloneSite
+from Products.PloneTestCase.setup import setupPloneSite
 
 from Products.CMFCore.interfaces import IActionCategory
 from Products.CMFCore.interfaces import IActionInfo
@@ -20,8 +20,9 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.tests.base.testcase import WarningInterceptor
 from Products.GenericSetup.context import TarballImportContext
 
-setupPloneSite()
+from Products.Five import zcml
 
+setupPloneSite(products=["plone.app.folder"])
 
 class MigrationTest(PloneTestCase):
 

--- a/plone/app/upgrade/tests/test_upgrade.py
+++ b/plone/app/upgrade/tests/test_upgrade.py
@@ -1,7 +1,8 @@
 from Products.CMFPlone.factory import _DEFAULT_PROFILE
 from Products.CMFCore.utils import getToolByName
-
+from plone.app.upgrade.utils import version_match
 from plone.app.upgrade.tests.base import MigrationTest
+import mock
 
 
 class TestUpgrade(MigrationTest):
@@ -23,6 +24,16 @@ class TestUpgrade(MigrationTest):
         current = tuple(current.split('.'))
         last = self.setup.getLastVersionForProfile(_DEFAULT_PROFILE)
         self.assertEqual(last, current)
+
+    @mock.patch('plone.app.upgrades.utils.plone_version', '5.0b1')
+    def testVersionMatch(self):
+        self.assertFalse(version_match('2.5'))
+        self.assertFalse(version_match('3.1b1'))
+        self.assertFalse(version_match('5.2.b1'))
+        self.assertTrue(version_match('5.0a3.dev0'))
+        self.assertTrue(version_match('5.0b1.dev0'))
+        self.assertTrue(version_match('5.0b3'))
+        self.assertTrue(version_match('5.0'))
 
     def testDoUpgrades(self):
         self.setRoles(['Manager'])

--- a/plone/app/upgrade/utils.py
+++ b/plone/app/upgrade/utils.py
@@ -11,9 +11,17 @@ from Products.GenericSetup.registry import _import_step_registry
 from Products.ZCatalog.ProgressHandler import ZLogHandler
 from ZODB.POSException import ConflictError
 
+import pkg_resources
+
 _marker = []
 
 logger = logging.getLogger('plone.app.upgrade')
+
+plone_version = pkg_resources.get_distribution("Products.CMFPlone").version
+
+
+def version_match(target):
+    return target <= plone_version < (target + 'zzzzzzz')
 
 
 def null_upgrade_step(tool):

--- a/plone/app/upgrade/utils.py
+++ b/plone/app/upgrade/utils.py
@@ -21,7 +21,13 @@ plone_version = pkg_resources.get_distribution("Products.CMFPlone").version
 
 
 def version_match(target):
-    return target <= plone_version < (target + 'zzzzzzz')
+    """ Given, our versioning scheme is always major.minorANYTHING, where major
+    and minor are single-digit numbers, we can compare versions as follows.
+    pkg_resources.parse_version is not compatible with our versioning scheme
+    (like '5.0b1') and also not compatible with the semver.org proposal
+    (requires '5.0-beta1').
+    """
+    return (target[0], target[1]) == (plone_version[0], plone_version[1])
 
 
 def null_upgrade_step(tool):

--- a/plone/app/upgrade/v25/tests.py
+++ b/plone/app/upgrade/v25/tests.py
@@ -4,6 +4,7 @@ from Products.CMFPlone.UnicodeSplitter import CaseNormalizer
 from plone.app.upgrade.tests.base import FunctionalUpgradeTestCase
 from plone.app.upgrade.tests.base import MigrationTest
 from plone.app.upgrade.utils import loadMigrationProfile
+from plone.app.upgrade.utils import version_match
 
 from plone.app.upgrade.v25 import fixupPloneLexicon
 from plone.app.upgrade.v25 import setLoginFormInCookieAuth
@@ -117,6 +118,8 @@ class TestFunctionalMigrations(FunctionalUpgradeTestCase):
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
+    if not version_match('2.5'):
+        return suite
     suite.addTest(makeSuite(TestMigrations_v2_5_0))
     suite.addTest(makeSuite(TestMigrations_v2_5_1))
     suite.addTest(makeSuite(TestMigrations_v2_5_2))

--- a/plone/app/upgrade/v30/tests.py
+++ b/plone/app/upgrade/v30/tests.py
@@ -74,6 +74,7 @@ from Products.ResourceRegistries.interfaces import IJSRegistry
 from plone.app.upgrade.tests.base import FunctionalUpgradeTestCase
 from plone.app.upgrade.tests.base import MigrationTest
 from plone.app.upgrade.utils import loadMigrationProfile
+from plone.app.upgrade.utils import version_match
 
 from plone.app.upgrade.v30.alphas import enableZope3Site
 from plone.app.upgrade.v30.alphas import migrateOldActions
@@ -1100,6 +1101,8 @@ class TestFunctionalMigrations(FunctionalUpgradeTestCase):
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
+    if not version_match('3.0'):
+        return suite
     suite.addTest(makeSuite(TestMigrations_v2_5_x))
     suite.addTest(makeSuite(TestMigrations_v3_0_Actions))
     suite.addTest(makeSuite(TestMigrations_v3_0_alpha1))

--- a/plone/app/upgrade/v31/tests.py
+++ b/plone/app/upgrade/v31/tests.py
@@ -5,6 +5,7 @@ from Products.PlonePAS.interfaces.plugins import ILocalRolesPlugin
 
 from plone.app.upgrade.tests.base import FunctionalUpgradeTestCase
 from plone.app.upgrade.tests.base import MigrationTest
+from plone.app.upgrade.utils import version_match
 
 from plone.app.upgrade.v31.betas import reinstallCMFPlacefulWorkflow
 
@@ -113,6 +114,8 @@ class TestFunctionalMigrations(FunctionalUpgradeTestCase):
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
+    if not version_match('3.1'):
+        return suite
     suite.addTest(makeSuite(TestMigrations_v3_1))
     suite.addTest(makeSuite(TestFunctionalMigrations))
     return suite

--- a/plone/app/upgrade/v32/tests.py
+++ b/plone/app/upgrade/v32/tests.py
@@ -1,5 +1,6 @@
 from plone.app.upgrade.tests.base import FunctionalUpgradeTestCase
 from plone.app.upgrade.tests.base import MigrationTest
+from plone.app.upgrade.utils import version_match
 from plone.app.upgrade.v32.betas import three1_beta1
 
 class TestMigrations_v3_2(MigrationTest):
@@ -45,6 +46,8 @@ class TestFunctionalMigrations(FunctionalUpgradeTestCase):
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
+    if not version_match('3.2'):
+        return suite
     suite.addTest(makeSuite(TestMigrations_v3_2))
     suite.addTest(makeSuite(TestFunctionalMigrations))
     return suite

--- a/plone/app/upgrade/v33/tests.py
+++ b/plone/app/upgrade/v33/tests.py
@@ -3,6 +3,8 @@ from Products.CMFCore.utils import getToolByName
 from plone.app.upgrade.tests.base import FunctionalUpgradeTestCase
 from plone.app.upgrade.tests.base import MigrationTest
 from plone.app.upgrade.v33 import three2_three3
+from plone.app.upgrade.utils import version_match
+
 
 class TestMigrations_v3_3(MigrationTest):
 
@@ -88,6 +90,8 @@ class TestFunctionalMigrations(FunctionalUpgradeTestCase):
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
+    if not version_match('3.3'):
+        return suite
     suite.addTest(makeSuite(TestMigrations_v3_3))
     suite.addTest(makeSuite(TestFunctionalMigrations))
     return suite

--- a/plone/app/upgrade/v40/tests.py
+++ b/plone/app/upgrade/v40/tests.py
@@ -30,6 +30,7 @@ from plone.app.upgrade.v40.betas import repositionRecursiveGroupsPlugin
 from plone.app.upgrade.v40.betas import updateIconMetadata
 from plone.app.upgrade.v40.betas import removeLargePloneFolder
 from plone.app.upgrade.tests.base import MigrationTest
+from plone.app.upgrade.utils import version_match
 
 from plone.portlet.static import static
 from plone.portlets.interfaces import IPortletAssignmentMapping
@@ -662,5 +663,7 @@ class TestMigrations_v4_0_5(MigrationTest):
 
 
 def test_suite():
-    from unittest import defaultTestLoader
-    return defaultTestLoader.loadTestsFromName(__name__)
+    import unittest
+    if not version_match('4.0'):
+        return unittest.TestSuite()
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(name='plone.app.upgrade',
       zip_safe=False,
       extras_require=dict(
         test=[
+            'mock',
             'Products.CMFPlacefulWorkflow',
             'Products.CMFQuickInstallerTool',
             'Products.PloneTestCase',


### PR DESCRIPTION
this is a trial/idea how to solve the problem with tests for older plone versions. Have a look and comment please.