### PR TITLE
4.3: Properly update TinyMCE, CMFEditions, Sunburst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 1.3.16 (unreleased)
 -------------------
 
+- Plone 4.3: upgrade TinyMCE correctly.  Update sunburst theme profile
+  version when applying its upgrade step.  Update CMFEditions.  Update
+  plone.app.jquery.
+  This fixes
+  https://github.com/plone/Products.CMFPlone/issues/812
+  [maurits]
+
 - Portal properties calendar_starting_year and calendar_future_years_available
   were moved to registry.
   [pbauer]

--- a/plone/app/upgrade/v42/final.py
+++ b/plone/app/upgrade/v42/final.py
@@ -13,25 +13,8 @@ def to42final_cmfeditions_registry_bases(context):
     # profile isn't installed and so has no installed version number.
     # this applies a necessary upgrade step but also establishes a
     # version for the profile
-    setup = getToolByName(context, 'portal_setup')
-
-    # Copied from Products.GenericSetup.tool.SetupTool.manage_doUpgrades
-    logger = logging.getLogger('GenericSetup')
-    steps_to_run = ['36634937']
-    profile_id = 'Products.CMFEditions:CMFEditions'
-    step = None
-    for step_id in steps_to_run:
-        step = _upgrade_registry.getUpgradeStep(profile_id, step_id)
-        if step is not None:
-            step.doStep(setup)
-            msg = "Ran upgrade step %s for profile %s" % (step.title,
-                                                          profile_id)
-            logger.log(logging.INFO, msg)
-
-    # We update the profile version to the last one we have reached
-    # with running an upgrade step.
-    if step and step.dest is not None and step.checker is None:
-        setup.setLastVersionForProfile(profile_id, step.dest)
+    qi = getToolByName(context, 'portal_quickinstaller')
+    qi.upgradeProduct('Products.CMFEditions')
 
 
 def to42final(context):

--- a/plone/app/upgrade/v43/alphas.py
+++ b/plone/app/upgrade/v43/alphas.py
@@ -69,13 +69,17 @@ def upgradeToI18NCaseNormalizer(context):
 
 def upgradeTinyMCE(context):
     """ Upgrade TinyMCE WYSIWYG Editor to jQuery based version 1.3
+
+    This is profile version 4.
     """
     try:
-        from Products.TinyMCE.upgrades import upgrade_12_to_13
+        # Is the package still there?  Not on Plone 5.
+        import Products.TinyMCE.upgrades
+        Products.TinyMCE.upgrades  # pyflakes
     except ImportError:
-        pass
-    else:
-        upgrade_12_to_13(context)
+        return
+    context.upgradeProfile('Products.TinyMCE:TinyMCE', dest='4')
+
 
 def upgradePloneAppTheming(context):
     """Re-install plone.app.theming if previously installed
@@ -101,14 +105,18 @@ def upgradePloneAppTheming(context):
     portal_setup = getToolByName(context, 'portal_setup')
     return portal_setup.runAllImportStepsFromProfile('profile-plone.app.theming:default')
 
+
 def upgradePloneAppJQuery(context):
-    """ Upgrade TinyMCE WYSIWYG Editor to jQuery based version 1.3
+    """ Upgrade plone.app.jquery to profile version 3.
     """
     try:
-        from plone.app.jquery.upgrades import upgrade_2_to_3
-        upgrade_2_to_3(context)
+        # Is the package still there?  Not on Plone 5.
+        import plone.app.jquery
+        plone.app.jquery  # pyflakes
     except ImportError:
-        pass
+        return
+    context.upgradeProfile('plone.app.jquery:default', dest='3')
+
 
 def to43alpha1(context):
     """4.2 -> 4.3alpha1"""
@@ -116,9 +124,7 @@ def to43alpha1(context):
     reindex_sortable_title(context)
     upgradeTinyMCE(context)
     upgradePloneAppTheming(context)
-    # XXX only for plone.app.jquery 1.7
-    # we're on 1.4 right now
-    # upgradePloneAppJQuery(context)
+    upgradePloneAppJQuery(context)
 
 
 def upgradeSyndication(context):
@@ -231,6 +237,10 @@ def removeKSS(context):
 
 
 def upgradeTinyMCEAgain(context):
-    qi = getToolByName(context, 'portal_quickinstaller')
-    if 'Products.TinyMCE' in qi:
-        qi.upgradeProduct('Products.TinyMCE')
+    try:
+        # Is the package still there?  Not on Plone 5.
+        import Products.TinyMCE.upgrades
+        Products.TinyMCE.upgrades  # pyflakes
+    except ImportError:
+        return
+    context.upgradeProfile('Products.TinyMCE:TinyMCE')

--- a/plone/app/upgrade/v43/betas.py
+++ b/plone/app/upgrade/v43/betas.py
@@ -1,8 +1,10 @@
 from plone.app.upgrade.utils import loadMigrationProfile
 from plone.app.upgrade.v43.alphas import upgradeToI18NCaseNormalizer
 
+
 def to43beta2(context):
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v43:to43beta2')
+
 
 def to43rc1(context):
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v43:to43rc1')
@@ -13,8 +15,9 @@ def upgradeSunburst(context):
     """ Upgrade plonetheme.sunburst to version 1.4
     """
     try:
-        from plonetheme.sunburst.setuphandlers import upgrade_step_2_3
+        # Is the package still there?  Not on Plone 5.
+        import plonetheme.sunburst
+        plonetheme.sunburst  # pyflakes
     except ImportError:
-        pass
-    else:
-        upgrade_step_2_3(context)
+        return
+    context.upgradeProfile('plonetheme.sunburst:default', dest='3')

--- a/plone/app/upgrade/v43/final.py
+++ b/plone/app/upgrade/v43/final.py
@@ -7,7 +7,11 @@ from plone.contentrules.engine.assignments import check_rules_with_dotted_name_m
 
 from plone.app.upgrade.utils import loadMigrationProfile
 from plone.app.upgrade.utils import unregisterSteps
+from plone.app.upgrade.v43.alphas import upgradeTinyMCEAgain
 
+# We had our own version of this, but it was just a copy.  We keep a
+# reference here to avoid breakage if someone imports it.
+upgradeTinyMCEAgain  # Pyflakes
 logger = logging.getLogger('plone.app.upgrade')
 
 
@@ -30,12 +34,6 @@ def upgradeContentRulesNames(context):
     storage = queryUtility(IRuleStorage)
     for key in storage.keys():
         check_rules_with_dotted_name_moved(storage[key])
-
-
-def upgradeTinyMCEAgain(context):
-    qi = getToolByName(context, 'portal_quickinstaller')
-    if 'Products.TinyMCE' in qi:
-        qi.upgradeProduct('Products.TinyMCE')
 
 
 def removePersistentKSSMimeTypeImportStep(context):


### PR DESCRIPTION
This fixes issue https://github.com/plone/Products.CMFPlone/issues/812

It fixes existing upgrade steps.

I think we should also explicitly run those upgrade steps again in Plone 4.3.7, to make sure these three packages are really updated for everyone. I added commit ba0f141f84087a30cc7dee1675c951a3b0bbf611 for that, but reverted it as it needs an update to metadata.xml in CMFPlone. Now it is available for easy cherry-picking.