### PR TITLE
Connect Users & Groups control panel settings to their registry entries.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.14 (unreleased)
 -------------------
 
+- Connect Users & Groups control panel settings to their registry entries.
+  [esteele]
+
 - Remove plone_forms skins folder for 5.0 rc1
   [esteele]
 

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -3,6 +3,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IMailSchema
 from Products.CMFPlone.interfaces import IMarkupSchema
 from Products.CMFPlone.interfaces import ISecuritySchema
+from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
 from Products.CMFPlone.interfaces import ILanguageSchema
 from plone.app.linkintegrity.upgrades import migrate_linkintegrity_relations
 from plone.app.upgrade.utils import loadMigrationProfile
@@ -279,6 +280,39 @@ def upgrade_querystring(context):
     context.upgradeProfile('plone.app.querystring:default')
 
 
+def upgrade_usergroups_controlpanel_settings(context):
+    """Copy users and groups control panel settings from portal properties
+    into the new registry.
+    """
+
+    # get the old site properties
+    portal_url = getToolByName(context, 'portal_url')
+    portal = portal_url.getPortalObject()
+    portal_properties = getToolByName(portal, "portal_properties")
+    site_properties = portal_properties.site_properties
+
+    # get the new registry
+    registry = getUtility(IRegistry)
+
+    # XXX: Somehow this code is executed for old migration steps as well
+    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
+    # registry interfaces with 'check=False' will not work, because it will
+    # return a settings object and then fail when we try to access the
+    # attributes.
+    try:
+        settings = registry.forInterface(IUserGroupsSettingsSchema,
+                                         prefix='plone')
+    except KeyError:
+        settings = False
+    if settings:
+        settings.many_groups = site_properties.getProperty('many_groups',
+                                                           False)
+        settings.many_users = site_properties.getProperty('many_users',
+                                                          False)
+
+
 def to50rc1(context):
     """5.0beta4 -> 5.0rc1"""
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v50:to50rc1')
+
+    upgrade_usergroups_controlpanel_settings(context)


### PR DESCRIPTION
Use the configuration registry for storing the many_users/many_groups properties.

See also https://github.com/plone/Products.CMFPlone/pull/863