### PR TITLE
Portal properties cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.14 (unreleased)
 -------------------
 
+- Connect Users & Groups control panel settings to their registry entries.
+  [esteele]
+
 - Remove plone_forms skins folder for 5.0 rc1
   [esteele]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.3.14 (unreleased)
 -------------------
 
-- Connect Users & Groups control panel settings to their registry entries.
+- Remove no-longer-used properties from portal_properties
   [esteele]
 
 - Remove plone_forms skins folder for 5.0 rc1

--- a/plone/app/upgrade/v43/tests.py
+++ b/plone/app/upgrade/v43/tests.py
@@ -22,6 +22,8 @@ class TestMigrations_v4_3alpha1(MigrationTest):
         self.assertTrue(True)
 
     def testAddDisplayPublicationDateInBylineProperty(self):
+        if PLONE5:
+            return
         pprop = getToolByName(self.portal, 'portal_properties')
         self.assertEqual(
             pprop.site_properties.getProperty('displayPublicationDateInByline'),

--- a/plone/app/upgrade/v50/alphas.py
+++ b/plone/app/upgrade/v50/alphas.py
@@ -86,8 +86,11 @@ def migrate_registry_settings(portal):
     registry['plone.site_title'] = portal.title.decode('utf8')
     registry['plone.webstats_js'] = site_props.webstats_js.decode('utf8')
     registry['plone.enable_sitemap'] = site_props.enable_sitemap
-    registry['plone.exposeDCMetaTags'] = site_props.exposeDCMetaTags
-    registry['plone.enable_livesearch'] = site_props.enable_livesearch
+
+    if site_props.hasProperty('exposeDCMetaTags'):
+        registry['plone.exposeDCMetaTags'] = site_props.exposeDCMetaTags
+    if site_props.hasProperty('enable_livesearch'):
+        registry['plone.enable_livesearch'] = site_props.enable_livesearch
     registry['plone.types_not_searched'] = tuple(
         t for t in site_props.types_not_searched if t in portal_types)
 
@@ -168,10 +171,13 @@ def upgrade_editing_controlpanel_settings(context):
         settings = False
     if settings:
         # migrate the old site properties to the new registry
-        settings.visible_ids = site_properties.visible_ids
-        settings.enable_link_integrity_checks = \
-            site_properties.enable_link_integrity_checks
-        settings.ext_editor = site_properties.ext_editor
+        if site_properties.hasProperty('visible_ids'):
+            settings.visible_ids = site_properties.visible_ids
+        if site_properties.hasProperty('enable_link_integrity_checks'):
+            settings.enable_link_integrity_checks = \
+                site_properties.enable_link_integrity_checks
+        if site_properties.hasProperty('ext_editor'):
+            settings.ext_editor = site_properties.ext_editor
         # settings.available_editors = site_properties.available_editors
 
         # Kupu will not be available as editor in Plone 5. Therefore we just
@@ -272,7 +278,8 @@ def upgrade_search_controlpanel_settings(context):
     except KeyError:
         settings = False
 
-    settings.enable_livesearch = site_properties.enable_livesearch
+    if site_properties.hasProperty('enable_livesearch'):
+        settings.enable_livesearch = site_properties.enable_livesearch
     settings.types_not_searched = tuple([
         t for t in types_tool.listContentTypes()
         if t not in site_properties.types_not_searched and
@@ -305,4 +312,6 @@ def upgrade_site_controlpanel_settings(context):
     settings.site_title = unicode(portal.title)
     settings.webstats_js = unicode(site_properties.webstats_js)
     settings.enable_sitemap = site_properties.enable_sitemap
-    settings.exposeDCMetaTags = site_properties.exposeDCMetaTags
+    if site_properties.hasProperty('exposeDCMetaTags'):
+        settings.exposeDCMetaTags = site_properties.exposeDCMetaTags
+    

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -323,9 +323,11 @@ def to50rc1(context):
     pprop = getToolByName(portal, 'portal_properties')
     site_properties = pprop['site_properties']
 
-    registry = getUtility(IRegistry)
-    settings = registry.forInterface(ISiteSchema, prefix='plone')
-    settings.icon_visiblity = site_properties.icon_visiblity
+    if site_properties.hasProperty('icon_visibility'):
+        registry = getUtility(IRegistry)
+        settings = registry.forInterface(ISiteSchema, prefix='plone')
+        value = site_properties.getProperty('icon_visibility', 'false')
+        settings.icon_visiblity = value
 
     # These have been migrated in previous upgrade steps. Safe to remove.
     properties_to_remove = ['allowAnonymousViewAbout',

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -357,4 +357,3 @@ def to50rc1(context):
         if site_properties.hasProperty(p):
             site_properties._delProperty(p)
 
-    import pdb; pdb.set_trace( )

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -326,6 +326,7 @@ def to50rc1(context):
     properties_to_remove = ['allowAnonymousViewAbout',
                             'available_editors',
                             'default_contenttype',
+                            'default_language',
                             'default_editor',
                             'disable_folder_sections',
                             'disable_nonfolderish_sections',

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -3,6 +3,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IMailSchema
 from Products.CMFPlone.interfaces import IMarkupSchema
 from Products.CMFPlone.interfaces import ISecuritySchema
+from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
 from Products.CMFPlone.interfaces import ILanguageSchema
 from plone.app.linkintegrity.upgrades import migrate_linkintegrity_relations
 from plone.app.upgrade.utils import loadMigrationProfile
@@ -279,6 +280,39 @@ def upgrade_querystring(context):
     context.upgradeProfile('plone.app.querystring:default')
 
 
+def upgrade_usergroups_controlpanel_settings(context):
+    """Copy users and groups control panel settings from portal properties
+    into the new registry.
+    """
+
+    # get the old site properties
+    portal_url = getToolByName(context, 'portal_url')
+    portal = portal_url.getPortalObject()
+    portal_properties = getToolByName(portal, "portal_properties")
+    site_properties = portal_properties.site_properties
+
+    # get the new registry
+    registry = getUtility(IRegistry)
+
+    # XXX: Somehow this code is executed for old migration steps as well
+    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
+    # registry interfaces with 'check=False' will not work, because it will
+    # return a settings object and then fail when we try to access the
+    # attributes.
+    try:
+        settings = registry.forInterface(IUserGroupsSettingsSchema,
+                                         prefix='plone')
+    except KeyError:
+        settings = False
+    if settings:
+        settings.many_groups = site_properties.getProperty('many_groups',
+                                                           False)
+        settings.many_users = site_properties.getProperty('many_users',
+                                                          False)
+
+
 def to50rc1(context):
     """5.0beta4 -> 5.0rc1"""
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v50:to50rc1')
+
+    upgrade_usergroups_controlpanel_settings(context)

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -36,8 +36,7 @@ def upgrade_portal_language(context):
 
     # Merge default language options to registry
     portal = getUtility(ISiteRoot)
-    if portal.hasProperty('default_language'):
-        default_lang = portal.getProperty('default_language')
+    default_lang = portal.getProperty('default_language', 'en')
 
     portal_properties = getToolByName(context, "portal_properties", None)
     if portal_properties is not None:

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -316,3 +316,45 @@ def to50rc1(context):
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v50:to50rc1')
 
     upgrade_usergroups_controlpanel_settings(context)
+
+    portal = getSite()
+    # Migrate settings from portal_properties to the configuration registry
+    pprop = getToolByName(portal, 'portal_properties')
+    site_properties = pprop['site_properties']
+
+    # These have been migrated in previous upgrade steps. Safe to remove.
+    properties_to_remove = ['allowAnonymousViewAbout',
+                            'available_editors',
+                            'default_contenttype',
+                            'default_editor',
+                            'disable_folder_sections',
+                            'disable_nonfolderish_sections',
+                            'enable_inline_editing',
+                            'enable_link_integrity_checks',
+                            'enable_livesearch',
+                            'enable_sitemap',
+                            'exposeDCMetaTags',
+                            'ext_editor',
+                            'forbidden_contenttypes',
+                            'lock_on_ttw_edit',
+                            'many_groups',
+                            'many_users',
+                            'number_of_days_to_keep',
+                            'search_collapse_options',
+                            'search_enable_batch_size',
+                            'search_enable_description_search',
+                            'search_review_state_for_anon',
+                            'search_enable_sort_on',
+                            'search_enable_title_search',
+                            'types_not_searched',
+                            'use_email_as_login',
+                            'use_folder_contents',
+                            'use_uuid_as_userid',
+                            'user_registration_fields',
+                            'visible_ids',
+                            'webstats_js']
+    for p in properties_to_remove:
+        if site_properties.hasProperty(p):
+            site_properties._delProperty(p)
+
+    import pdb; pdb.set_trace( )

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -3,7 +3,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IMailSchema
 from Products.CMFPlone.interfaces import IMarkupSchema
 from Products.CMFPlone.interfaces import ISecuritySchema
-from Products.CMFPlone.interfaces import ISiteSettingsSchema
+from Products.CMFPlone.interfaces import ISiteSchema
 from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
 from Products.CMFPlone.interfaces import ILanguageSchema
 from plone.app.linkintegrity.upgrades import migrate_linkintegrity_relations
@@ -324,7 +324,7 @@ def to50rc1(context):
     site_properties = pprop['site_properties']
 
     registry = getUtility(IRegistry)
-    settings = registry.forInterface(ISiteSettingsSchema, prefix='plone')
+    settings = registry.forInterface(ISiteSchema, prefix='plone')
     settings.icon_visiblity = site_properties.icon_visiblity
 
     # These have been migrated in previous upgrade steps. Safe to remove.

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -3,6 +3,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IMailSchema
 from Products.CMFPlone.interfaces import IMarkupSchema
 from Products.CMFPlone.interfaces import ISecuritySchema
+from Products.CMFPlone.interfaces import ISiteSettingsSchema
 from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
 from Products.CMFPlone.interfaces import ILanguageSchema
 from plone.app.linkintegrity.upgrades import migrate_linkintegrity_relations
@@ -322,6 +323,10 @@ def to50rc1(context):
     pprop = getToolByName(portal, 'portal_properties')
     site_properties = pprop['site_properties']
 
+    registry = getUtility(IRegistry)
+    settings = registry.forInterface(ISiteSettingsSchema, prefix='plone')
+    settings.icon_visiblity = site_properties.icon_visiblity
+
     # These have been migrated in previous upgrade steps. Safe to remove.
     properties_to_remove = ['allowAnonymousViewAbout',
                             'available_editors',
@@ -337,6 +342,7 @@ def to50rc1(context):
                             'exposeDCMetaTags',
                             'ext_editor',
                             'forbidden_contenttypes',
+                            'icon_visibility',
                             'lock_on_ttw_edit',
                             'many_groups',
                             'many_users',

--- a/plone/app/upgrade/v50/profiles/to_rc1/registry.xml
+++ b/plone/app/upgrade/v50/profiles/to_rc1/registry.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<registry>
+  <records interface="Products.CMFPlone.interfaces.ISiteSchema"
+           prefix="plone" />
+</registry>

--- a/plone/app/upgrade/v50/tests.py
+++ b/plone/app/upgrade/v50/tests.py
@@ -1,9 +1,11 @@
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.interfaces import ISecuritySchema
 from plone.app.upgrade.tests.base import MigrationTest
 from plone.app.upgrade.v50.testing import REAL_UPGRADE_FUNCTIONAL
 from plone.app.viewletmanager.interfaces import IViewletSettingsStorage
 from plone.portlets.interfaces import IPortletAssignmentMapping
 from plone.portlets.interfaces import IPortletManager
+from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import Browser
 from zope.component import getMultiAdapter
 from zope.component import getSiteManager
@@ -42,8 +44,10 @@ class PASUpgradeTest(MigrationTest):
 
         # If email as login is enabled, we want to use lowercase login
         # names, even when that login name is not an email address.
-        ptool = getToolByName(self.portal, 'portal_properties')
-        ptool.site_properties.manage_changeProperties(use_email_as_login=True)
+        registry = getUtility(IRegistry)
+        security_settings = registry.forInterface(ISecuritySchema,
+                                                  prefix="plone")
+        security_settings.use_email_as_login = True
 
         # Second call.
         alphas.lowercase_email_login(self.portal)


### PR DESCRIPTION
These properties either:
* Have been migrated to the configuration registry
* Are no longer used in Plone core

See also: https://github.com/plone/Products.CMFPlone/pull/864