### PR TITLE
Cleanup profiles and products.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,19 @@ Changelog
 1.3.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Cleanup uninstalled products.  Remove uninstalled products from QI
+  and mark their installed profile version as unknown.
+  [maurits]
+
+- If non installable profiles (really: hidden profiles) have been
+  installed in GS, mark their products as installed in the QI.  This
+  does not work when also that *product* is marked as non installable,
+  because in normal operation (outside of plone.app.upgrade) this does
+  not happen either.
+  [maurits]
+
+- Unmark installed profiles that are no longer available.
+  [maurits]
 
 
 1.3.16 (2015-09-20)

--- a/plone/app/upgrade/v43/configure.zcml
+++ b/plone/app/upgrade/v43/configure.zcml
@@ -182,6 +182,24 @@
             handler=".final.improveSyndication"
             />
 
+       <genericsetup:upgradeStep
+           title="Unmark installed profiles that are no longer available."
+           description="This removes no longer interesting info."
+           handler="plone.app.upgrade.v43.final.unmarkUnavailableProfiles"
+           />
+
+       <genericsetup:upgradeStep
+           title="Mark products as installed for installed uninstallable profiles"
+           description="The profiles were meant to be hidden, not uninstallable."
+           handler="plone.app.upgrade.v43.final.markProductsInstalledForUninstallableProfiles"
+           />
+
+       <genericsetup:upgradeStep
+           title="Cleanup uninstalled products"
+           description="Remove uninstalled products from QI and mark their profiles as unknown."
+           handler="plone.app.upgrade.v43.final.cleanupUninstalledProducts"
+           />
+
     </genericsetup:upgradeSteps>
 
 </configure>

--- a/plone/app/upgrade/v43/final.py
+++ b/plone/app/upgrade/v43/final.py
@@ -1,6 +1,8 @@
 import logging
 from Products.CMFCore.utils import getToolByName
+from Products.GenericSetup import EXTENSION
 
+from zope.component import getAllUtilitiesRegisteredFor
 from zope.component import queryUtility
 from plone.contentrules.engine.interfaces import IRuleStorage
 from plone.contentrules.engine.assignments import check_rules_with_dotted_name_moved
@@ -53,3 +55,204 @@ def addShowInactiveCriteria(context):
 
 def improveSyndication(context):
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v43:to435')
+
+
+def unmarkUnavailableProfiles(context):
+    """Unmark installed profiles that are no longer available.
+    """
+    setup = context
+    available = [profile['id'] for profile in setup.listProfileInfo()]
+    # XXX We want to use unsetLastVersionForProfile,
+    # but that requires a merge and release of this
+    # GenericSetup pull request:
+    # https://github.com/zopefoundation/Products.GenericSetup/pull/18
+    # portal_setup.unsetLastVersionForProfile(profile_id)
+    # Instead we must copy and set the
+    # (non-persistent) profile upgrade versions.
+    prof_versions = setup._profile_upgrade_versions.copy()
+    to_remove = [profile_id for profile_id in prof_versions
+                 if profile_id not in available]
+    if not to_remove:
+        return
+    for profile_id in to_remove:
+        logger.info('Setting installed version of profile %s as unknown.',
+                    profile_id)
+        del prof_versions[profile_id]
+    # save the new dictionary
+    setup._profile_upgrade_versions = prof_versions
+
+
+def markProductsInstalledForUninstallableProfiles(context):
+    """Cleanup uninstalled products.
+
+    QI 3.0.8 (Plone 4.3.5 / 5.0b1) no longer prevents INonInstallable
+    profiles from being recorded as QI installed products, because
+    really they are auto-installed products, not non-installable ones.
+
+    This means we should do some migration.
+
+    Go through all INonInstallable profiles, check if the profile was
+    applied and mark it as installed in QI.  This might mark too many
+    of these as installed, but so be it.
+
+    But: there are also INonInstallable products.  These are ignored
+    by the QI events.  So if the non installable profile of a non
+    installable product gets applied, the product is still NOT marked
+    as installed in the QI.  So we should not do that here either, but
+    that goes fine because we use the same logic.
+
+    In Plone 5.0, these packages fall under both categories:
+
+    [
+    'Archetypes',
+    'CMFDiffTool',
+    'CMFEditions',
+    'CMFFormController',
+    'CMFPlone',
+    'CMFQuickInstallerTool',
+    'MimetypesRegistry',
+    'NuPlone',
+    'PasswordResetTool',
+    'PloneLanguageTool',
+    'PlonePAS',
+    'PortalTransforms',
+    'borg.localrole',
+    'plone.app.blob',
+    'plone.app.collection',
+    'plone.app.dexterity',
+    'plone.app.discussion',
+    'plone.app.event',
+    'plone.app.folder',
+    'plone.app.imaging',
+    'plone.app.querystring',
+    'plone.app.registry',
+    'plone.app.theming',
+    'plone.formwidget.recurrence',
+    'plone.keyring',
+    'plone.outputfilters',
+    'plone.portlet.collection',
+    'plone.portlet.static',
+    'plone.protect',
+    'plone.resource',
+    ]
+
+    These only fall under non installable profiles:
+
+    [
+    'plone.app.contenttypes',
+    'plone.app.multilingual',
+    'plone.app.versioningbehavior',
+    'plone.browserlayer',
+    ]
+
+    BTW, plone.browserlayer does not even have a profile...
+
+    These only fall under non installable products:
+
+    [
+    'CMFDefault',
+    'CMFPlone.migrations',
+    'CMFTopic',
+    'CMFUid',
+    'DCWorkflow',
+    'plone.app.caching',
+    'plone.app.intid',
+    'plone.app.referenceablebehavior',
+    'plone.app.relationfield',
+    'plone.app.upgrade.v25',
+    'plone.app.upgrade.v30',
+    'plone.app.upgrade.v31',
+    'plone.app.upgrade.v32',
+    'plone.app.upgrade.v33',
+    'plone.app.upgrade.v40',
+    'plone.app.upgrade.v41',
+    'plone.app.upgrade.v42',
+    'plone.app.upgrade.v43',
+    'plone.app.widgets',
+    'plone.app.z3cform',
+    'plonetheme.barceloneta',
+    'wicked.at',
+    ]
+    """
+    from Products.CMFPlone.interfaces import INonInstallable
+    setup = context
+    qi = getToolByName(context, 'portal_quickinstaller')
+    # Get list of profiles that are marked as not installable.
+    profile_ids = []
+    utils = getAllUtilitiesRegisteredFor(INonInstallable)
+    for util in utils:
+        profile_ids.extend(util.getNonInstallableProfiles())
+    # If non installable profiles (really: hidden profiles) have been
+    # installed in GS, mark their products as installed in the QI.
+    for profile_id in profile_ids:
+        if setup.getLastVersionForProfile(profile_id) == 'unknown':
+            # not installed
+            continue
+        # Profile was installed.  Mark its corresponding product as
+        # installed too.
+        try:
+            profile = setup.getProfileInfo(profile_id)
+        except KeyError:
+            # Profile was installed at some point, but is no longer
+            # available.  Should have been caught by the
+            # unmarkUnavailableProfiles upgrade step, but let's be
+            # careful.
+            continue
+        product_id = profile['product']
+        if qi.isProductInstalled(product_id):
+            # all is well
+            continue
+        version = qi.getProductVersion(product_id)
+        qi.notifyInstalled(
+            product_id,
+            locked=False,
+            logmsg="Marked as installed by plone.app.upgrade",
+            settings={},
+            installedversion=version,
+            status='installed',
+            error=False,
+        )
+
+
+def cleanupUninstalledProducts(context):
+    """Cleanup uninstalled products.
+
+    QI 3.0.7 (Plone 4.3.4 / 5.0a3) removes the InstalledProduct
+    instance when a product is uninstalled, because leaving the
+    instance around can prevent settings from being stored properly
+    on subsequent installation of the product.
+
+    QI 3.0.12 (unreleased, maybe Plone 4.3.7 / 5.0rc3), marks
+    install profiles as unknown when uninstalling a product, so
+    portal_setup also regards it as not installed.
+
+    This means we should do some migration.
+
+    Go through all InstalledProduct items in the QI and remove any
+    that are not installed.  And unset their last profile versions in
+    GS too.
+    """
+    setup = context
+    qi = getToolByName(context, 'portal_quickinstaller')
+    for prod in qi.objectValues():
+        if prod.isInstalled():
+            continue
+        product_id = prod.id
+        qi.manage_delObjects(product_id)
+        profile = qi.getInstallProfile(product_id)
+        if profile is None:
+            continue
+        # Mark profile as uninstalled/unknown.
+        profile_id = profile['id']
+        # XXX We want to use unsetLastVersionForProfile,
+        # but that requires a merge and release of this
+        # GenericSetup pull request:
+        # https://github.com/zopefoundation/Products.GenericSetup/pull/18
+        # portal_setup.unsetLastVersionForProfile(profile_id)
+        # Instead we must copy and set the
+        # (non-persistent) profile upgrade versions.
+        prof_versions = setup._profile_upgrade_versions.copy()
+        if profile_id not in prof_versions:
+            continue
+        del prof_versions[profile_id]
+        setup._profile_upgrade_versions = prof_versions

--- a/plone/app/upgrade/v50/configure.zcml
+++ b/plone/app/upgrade/v50/configure.zcml
@@ -198,6 +198,24 @@
            handler=".betas.to50rc3"
            />
 
+       <gs:upgradeStep
+           title="Unmark installed profiles that are no longer available."
+           description="This removes no longer interesting info."
+           handler="plone.app.upgrade.v43.final.unmarkUnavailableProfiles"
+           />
+
+       <gs:upgradeStep
+           title="Mark products as installed for installed uninstallable profiles"
+           description="The profiles were meant to be hidden, not uninstallable."
+           handler="plone.app.upgrade.v43.final.markProductsInstalledForUninstallableProfiles"
+           />
+
+       <gs:upgradeStep
+           title="Cleanup uninstalled products"
+           description="Remove uninstalled products from QI and mark their profiles as unknown."
+           handler="plone.app.upgrade.v43.final.cleanupUninstalledProducts"
+           />
+
     </gs:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
1. Unmark installed profiles that are no longer available.

2. If non installable profiles (really: hidden profiles) have been
installed in GS, mark their products as installed in the QI.  This
does not work when also that *product* is marked as non installable,
because in normal operation (outside of plone.app.upgrade) this does
not happen either.

3. Remove uninstalled products from QI and mark their installed
profile version as unknown.

This is related to my post to plone-dev a month ago: http://permalink.gmane.org/gmane.comp.web.zope.plone.devel/35442
That post lists four TODO items.
- First TODO item: https://github.com/plone/Products.CMFQuickInstallerTool/pull/12
- Second TODO item is part of: https://github.com/plone/plone.app.upgrade/pull/42
- Third and fourth TODO item: this pull request. Plus an extra one, number one above.

This pull request depends on the first pull request, in the sense that the first pull adds a behavior to the QI and a part of this third pull request handles the migration so it looks like the behavior was always there.

This last pull request could be split in three parts, but it seems better to me to review them together.

This one is the trickiest. Might be too dangerous to include in Plone 5.0 at the last moment. Then again, 5.0 is a nice point for such a cleanup.

This should also be done in 4.3, but the CMFPlone profile version has not been updated yet, so I have temporarily put them in the 4309->4310 upgrade, They should be in the not yet existing 4310->4311 upgrade. That is probably best done after merging, in parallel with a commit to bump the CMFPlone profile version.