### PR TITLE
Remove fake kupu tool and related settings and resources.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.19 (unreleased)
 -------------------
 
+- Remove fake kupu tool and related settings and resources.
+  [maurits]
+
 - Cleanup the skins tool.
   [maurits]
 

--- a/plone/app/upgrade/kupu_bbb.py
+++ b/plone/app/upgrade/kupu_bbb.py
@@ -25,3 +25,6 @@ class PloneKupuLibraryTool(SimpleItem.SimpleItem):
                 a = []
             res.append((t, a))
         return res
+
+    def isKupuEnabled(self, *args, **kwargs):
+        return False

--- a/plone/app/upgrade/v43/configure.zcml
+++ b/plone/app/upgrade/v43/configure.zcml
@@ -224,6 +224,11 @@
             handler="plone.app.upgrade.v40.alphas.cleanUpSkinsTool"
             />
 
+        <genericsetup:upgradeStep
+            title="Remove fake kupu tool and related settings and resources."
+            handler="plone.app.upgrade.v43.final.removeFakeKupu"
+            />
+
     </genericsetup:upgradeSteps>
 
 </configure>

--- a/plone/app/upgrade/v50/configure.zcml
+++ b/plone/app/upgrade/v50/configure.zcml
@@ -259,6 +259,11 @@
            handler="plone.app.upgrade.v40.alphas.cleanUpSkinsTool"
            />
 
+       <gs:upgradeStep
+           title="Remove fake kupu tool and related settings and resources."
+           handler="plone.app.upgrade.v43.final.removeFakeKupu"
+           />
+
     </gs:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
plone.app.upgrade has a fake kupu tool class that is used when the Products.kupu package is not available.  This is a minimal working tool, so stuff does not break before we have had a chance to clean it up.

This fake kupu tool may be left behind, even when you have cleanly uninstalled kupu beforehand.

So we remove the fake tool and remove related settings and resources.

When Products.kupu is available as package, we do nothing: someone may actually still use kupu and it may actually still work.