### PR TITLE
Zope4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Fix ``cleanUpProductRegistry`` to not break when ``Control_Panel`` cannot be found.
+  Fixes test failures with Zope 4.
+  [thet]
 
 
 1.3.20 (2016-01-08)

--- a/plone/app/upgrade/v40/alphas.py
+++ b/plone/app/upgrade/v40/alphas.py
@@ -385,12 +385,14 @@ def cleanUpSkinsTool(context):
 
 
 def cleanUpProductRegistry(context):
-    control = getattr(context, 'Control_Panel')
-    products = control.Products
+    control = getattr(context, 'Control_Panel', None)
+    if control:
+        products = control.Products
 
-    # Remove all product entries
-    for name in products.keys():
-        products._delObject(name)
+        # Remove all product entries
+        for name in products.keys():
+            products._delObject(name)
+    # else: pass  # Zope 4 doesn't have the Control_Panel anymore
 
 
 def migrateStaticTextPortlets(context):


### PR DESCRIPTION
Fix cleanUpProductRegistry to not break when Control_Panel cannot be found.  Fixes test failures with Zope 4.