### PR TITLE
Add 5.1a2 profile to allow upgrades from Plone 5.1a1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -278,7 +278,10 @@ New:
   [jensens]
 
 - Update to 5.1a2 upgrade step to allow upgrades from Plone 5.1a1.
-  [jensens]
+  [jensens, bsuttor]
+
+- Add leadimage registry settings.
+  [bsuttor]
 
 
 1.3.24 (2016-03-31)

--- a/plone/app/upgrade/v51/alphas.py
+++ b/plone/app/upgrade/v51/alphas.py
@@ -34,4 +34,5 @@ def to51alpha1(context):
 
 
 def to51alpha2(context):
+    """5.1a1 -> 5.1a2"""
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v51:to51alpha2')

--- a/plone/app/upgrade/v51/profiles/to_alpha2/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_alpha2/registry.xml
@@ -30,4 +30,19 @@
   <records prefix="plone.resources/mockup-registry" interface='Products.CMFPlone.interfaces.IResourceRegistry' remove="True"/>
   <records prefix="plone.resources/mockup-parser" interface='Products.CMFPlone.interfaces.IResourceRegistry' remove="True"/>
 
+  <record name="plone.lead_scale_name">
+    <field type="plone.registry.field.Choice">
+        <title>Leadimage scale</title>
+        <description>Please select scale which will be used.</description>
+        <vocabulary>plone.app.vocabularies.ImagesScales</vocabulary>
+    </field>
+    <value>mini</value>
+  </record>
+  <record name="plone.is_lead_visible">
+    <field type="plone.registry.field.Bool">
+        <title>Show Leadimage in content</title>
+    </field>
+    <value>True</value>
+  </record>
+
 </registry>


### PR DESCRIPTION
And add registry leadimage settings into 5.1a2 profile.

This PR is related to 
https://github.com/plone/Products.CMFPlone/pull/1524
and
https://github.com/plone/plone.app.contenttypes/pull/339
