### PR TITLE
Changes for CMFPlones bower components update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,9 @@ Incompatibilities:
 - *add item here*
 
 New:
+  
+- Remove deprecated ``mockup-registry`` and ``mockup-parser`` resources.
+  [thet]
 
 - Update ``last_compilation`` to deliver new bundles.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Incompatibilities:
 
 New:
 
+- Update ``last_compilation`` to deliver new bundles.
+  [thet]
+
+- Add missing ``jquery.browser`` dependency which is needed by patternslib.
+  [thet]
+
 - Adds controlpanel setting to enable navigation root bound keyword vocabularies.
   [jensens]
 

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -26,7 +26,12 @@
 
       <gs:upgradeStep
            title="Run to51alpha2 upgrade profile."
-           description=""
+           description="
+Limit tags/keywords to the current navigation root,
+Add missing ``jquery.browser`` dependency which is needed by patternslib,
+Update ``last_compilation`` to deliver new bundles,
+Remove deprecated ``mockup-registry`` and ``mockup-parser`` resources.
+           "
            handler=".alphas.to51alpha2"
            />
 

--- a/plone/app/upgrade/v51/profiles/to_alpha2/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_alpha2/registry.xml
@@ -9,4 +9,19 @@
       False
     </value>
   </records>
+
+  <!-- Add missing ``jquery.browser`` dependency which is needed by patternslib -->
+  <records prefix="plone.resources/jquery.browser" interface="Products.CMFPlone.interfaces.IResourceRegistry">
+      <value key="js">++plone++static/components/jquery.browser/dist/jquery.browser.js</value>
+      <value key="deps">jquery</value>
+  </records>
+
+  <!-- Update ``last_compilation`` to deliver new bundles -->
+  <records prefix="plone.bundles/plone" interface="Products.CMFPlone.interfaces.IBundleRegistry" purge="False">
+    <value key="last_compilation">2016-06-21 00:00:00</value>
+  </records>
+  <records prefix="plone.bundles/plone-logged-in" interface="Products.CMFPlone.interfaces.IBundleRegistry" purge="False">
+    <value key="last_compilation">2016-06-21 00:00:00</value>
+  </records>
+
 </registry>

--- a/plone/app/upgrade/v51/profiles/to_alpha2/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_alpha2/registry.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
 <registry>
+
+  <!-- Limit tags/keywords to the current navigation root -->
   <records
       interface="Products.CMFPlone.interfaces.controlpanel.IEditingSchema"
       prefix="plone">
@@ -23,5 +25,9 @@
   <records prefix="plone.bundles/plone-logged-in" interface="Products.CMFPlone.interfaces.IBundleRegistry" purge="False">
     <value key="last_compilation">2016-06-21 00:00:00</value>
   </records>
+
+  <!-- Remove deprecated ``mockup-registry`` and ``mockup-parser`` resources -->
+  <records prefix="plone.resources/mockup-registry" interface='Products.CMFPlone.interfaces.IResourceRegistry' remove="True"/>
+  <records prefix="plone.resources/mockup-parser" interface='Products.CMFPlone.interfaces.IResourceRegistry' remove="True"/>
 
 </registry>


### PR DESCRIPTION
- Update ``last_compilation`` to deliver new bundles.
- Add missing ``jquery.browser`` dependency which is needed by patternslib.