### PR TITLE
Cast smtp port to int

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Be sure smtp_port is an integer.
+  [ale-rt]
 
 
 1.3.27 (2016-08-16)

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -96,7 +96,9 @@ def upgrade_mail_controlpanel_settings(context):
     mail_settings.smtp_host = unicode(smtp_host)
 
     smtp_port = getattr(portal.MailHost, 'smtp_port', 25)
-    mail_settings.smtp_port = smtp_port
+    # It may happen that smtp_port is a string, maybe empty,
+    # but we need an integer here to match the record constraints
+    mail_settings.smtp_port = int(smtp_port or 25)
 
     smtp_user_id = portal.MailHost.get('smtp_user_id')
     mail_settings.smtp_user_id = smtp_user_id


### PR DESCRIPTION
Fixes the cases where ``MailHost.smtp_port`` is a string.

In that case a ``WrongType`` exception is raised because of the ``mail_settings.smtp_port`` constraints.
```
WrongType: ('25', (<type 'int'>, <type 'long'>), 'value')
```