### PR TITLE
Support sites without portal_quickinstaller.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,15 @@ Breaking changes:
 
 New features:
 
+- Support sites without ``portal_quickinstaller``.
+  We use ``get_installer`` in Plone 5.1 migrations.
+  In earlier version we will keep using the ``portal_quickinstaller``,
+  because ``get_installer`` is not available.
+  In shared utility and base code, we try to import get_installer,
+  and fall back on the previous implementation.
+  See `PLIP 1340 <https://github.com/plone/Products.CMFPlone/issues/1340>`_.
+  [maurits]
+
 - Add new Mockup 2.4.0 relateditems resource url.
   [thet]
 

--- a/plone/app/upgrade/tests/base.py
+++ b/plone/app/upgrade/tests/base.py
@@ -87,9 +87,17 @@ class MigrationTest(PloneTestCase):
 
     def uninstallProduct(self, product_name):
         # Removes a product
-        tool = getToolByName(self.portal, 'portal_quickinstaller')
-        if tool.isProductInstalled(product_name):
-            tool.uninstallProducts([product_name])
+        try:
+            from Products.CMFPlone.utils import get_installer
+        except ImportError:
+            # BBB For Plone 5.0 and lower.
+            qi = getToolByName(self.portal, 'portal_quickinstaller', None)
+            if qi is None:
+                return
+        else:
+            qi = get_installer(self.portal)
+        if qi.isProductInstalled(product_name):
+            qi.uninstallProducts([product_name])
 
     def addSkinLayer(self, layer, skin='Plone Default', pos=None):
         # Adds a skin layer at pos. If pos is None, the layer is appended

--- a/plone/app/upgrade/utils.py
+++ b/plone/app/upgrade/utils.py
@@ -106,25 +106,45 @@ def installOrReinstallProduct(portal, product_name, out=None, hidden=False):
     If product is already installed test if it needs to be reinstalled. Also
     fix skins after reinstalling
     """
-    qi = getToolByName(portal, 'portal_quickinstaller')
-    if not qi.isProductInstalled(product_name):
-        qi.installProduct(product_name, hidden=hidden)
-        # Refresh skins
-        portal.clearCurrentSkin()
-        if getattr(portal, 'REQUEST', None):
-            portal.setupCurrentSkin(portal.REQUEST)
-        logger.info("Installed %s" % product_name)
+    try:
+        from Products.CMFPlone.utils import get_installer
+    except ImportError:
+        # BBB For Plone 5.0 and lower.
+        qi = getToolByName(portal, 'portal_quickinstaller', None)
+        if qi is None:
+            return
+        old_qi = True
     else:
-        info = qi._getOb(product_name)
-        installed_version = info.getInstalledVersion()
-        product_version = qi.getProductVersion(product_name)
-        if installed_version != product_version:
-            qi.reinstallProducts([product_name])
-            logger.info("%s is out of date (installed: %s/ filesystem: %s), "
-                        "reinstalled." % (product_name, installed_version,
-                                          product_version))
+        qi = get_installer(portal)
+        old_qi = False
+    if old_qi:
+        if not qi.isProductInstalled(product_name):
+            qi.installProduct(product_name, hidden=hidden)
+            logger.info("Installed %s" % product_name)
+        elif old_qi:
+            info = qi._getOb(product_name)
+            installed_version = info.getInstalledVersion()
+            product_version = qi.getProductVersion(product_name)
+            if installed_version != product_version:
+                qi.reinstallProducts([product_name])
+                logger.info("%s is out of date (installed: %s/ "
+                            "filesystem: %s), reinstalled." % (
+                                product_name, installed_version,
+                                product_version))
+            else:
+                logger.info('%s already installed.' % product_name)
+    else:
+        # New QI browser view.
+        if not qi.is_product_installed(product_name):
+            qi.install_product(product_name, allow_hidden=True)
+            logger.info("Installed %s" % product_name)
         else:
-            logger.info('%s already installed.' % product_name)
+            qi.upgrade_product(product_name)
+            logger.info("Upgraded %s", product_name)
+    # Refresh skins
+    portal.clearCurrentSkin()
+    if getattr(portal, 'REQUEST', None):
+        portal.setupCurrentSkin(portal.REQUEST)
 
 
 def loadMigrationProfile(context, profile, steps=_marker):

--- a/plone/app/upgrade/v30/tests.py
+++ b/plone/app/upgrade/v30/tests.py
@@ -837,7 +837,10 @@ class TestMigrations_v3_0_alpha2(MigrationTest):
         super(self.portal.__class__, self.portal).manage_delObjects(
             ['portal_languages'])
         self.uninstallProduct('PloneLanguageTool')
-        qi = getToolByName(self.portal, "portal_quickinstaller")
+        qi = getToolByName(self.portal, "portal_quickinstaller", None)
+        if qi is None:
+            # Newer Plone without qi.
+            return
         # Test it twice
         for i in range(2):
             installProduct('PloneLanguageTool', self.portal)

--- a/plone/app/upgrade/v31/betas.py
+++ b/plone/app/upgrade/v31/betas.py
@@ -29,14 +29,20 @@ def three0_beta1(portal):
 
 
 def addBrowserLayer(portal, out):
-    qi = getToolByName(portal, "portal_quickinstaller")
+    qi = getToolByName(portal, "portal_quickinstaller", None)
+    if qi is None:
+        # Newer Plone without qi.
+        return
     if not qi.isProductInstalled("plone.browserlayer"):
         qi.installProduct("plone.browserlayer", locked=True)
         out.append("Installed plone.browserlayer")
 
 
 def addCollectionAndStaticPortlets(portal, out):
-    qi = getToolByName(portal, "portal_quickinstaller")
+    qi = getToolByName(portal, "portal_quickinstaller", None)
+    if qi is None:
+        # Newer Plone without qi.
+        return
     if not qi.isProductInstalled("plone.portlet.static"):
         qi.installProduct("plone.portlet.static", locked=True)
         out.append("Installed plone.portlet.static")

--- a/plone/app/upgrade/v41/alphas.py
+++ b/plone/app/upgrade/v41/alphas.py
@@ -146,8 +146,8 @@ def update_controlpanel_permissions(context):
 
 
 def install_outputfilters(context):
-    qi = getToolByName(context, 'portal_quickinstaller')
-    if qi.isProductInstallable('plone.outputfilters'):
+    qi = getToolByName(context, 'portal_quickinstaller', None)
+    if qi is not None and qi.isProductInstallable('plone.outputfilters'):
         if not qi.isProductInstalled('plone.outputfilters'):
             qi.installProduct('plone.outputfilters')
 

--- a/plone/app/upgrade/v42/final.py
+++ b/plone/app/upgrade/v42/final.py
@@ -13,8 +13,9 @@ def to42final_cmfeditions_registry_bases(context):
     # profile isn't installed and so has no installed version number.
     # this applies a necessary upgrade step but also establishes a
     # version for the profile
-    qi = getToolByName(context, 'portal_quickinstaller')
-    qi.upgradeProduct('Products.CMFEditions')
+    qi = getToolByName(context, 'portal_quickinstaller', None)
+    if qi is not None:
+        qi.upgradeProduct('Products.CMFEditions')
 
 
 def to42final(context):

--- a/plone/app/upgrade/v43/alphas.py
+++ b/plone/app/upgrade/v43/alphas.py
@@ -232,8 +232,8 @@ def removeKSS(context):
     cleanUpToolRegistry(context)
 
     # make sure plone.app.kss is not activated in the quick installer
-    qi = getToolByName(context, 'portal_quickinstaller')
-    if qi.isProductInstalled('plone.app.kss'):
+    qi = getToolByName(context, 'portal_quickinstaller', None)
+    if qi is not None and qi.isProductInstalled('plone.app.kss'):
         qi.uninstallProduct('plone.app.kss')
 
 

--- a/plone/app/upgrade/v43/final.py
+++ b/plone/app/upgrade/v43/final.py
@@ -49,8 +49,9 @@ def addDefaultPlonePasswordPolicy(context):
 
 
 def addShowInactiveCriteria(context):
-    qi = getToolByName(context, 'portal_quickinstaller')
-    qi.upgradeProduct('plone.app.querystring')
+    qi = getToolByName(context, 'portal_quickinstaller', None)
+    if qi is not None:
+        qi.upgradeProduct('plone.app.querystring')
 
 
 def improveSyndication(context):
@@ -164,7 +165,9 @@ def markProductsInstalledForUninstallableProfiles(context):
     """
     from Products.CMFPlone.interfaces import INonInstallable
     setup = context
-    qi = getToolByName(context, 'portal_quickinstaller')
+    qi = getToolByName(context, 'portal_quickinstaller', None)
+    if qi is None:
+        return
     # Get list of profiles that are marked as not installable.
     profile_ids = []
     utils = getAllUtilitiesRegisteredFor(INonInstallable)
@@ -221,7 +224,9 @@ def cleanupUninstalledProducts(context):
     GS too.
     """
     setup = context
-    qi = getToolByName(context, 'portal_quickinstaller')
+    qi = getToolByName(context, 'portal_quickinstaller', None)
+    if qi is None:
+        return
     for prod in qi.objectValues():
         if prod.isInstalled():
             continue

--- a/plone/app/upgrade/v43/tests.py
+++ b/plone/app/upgrade/v43/tests.py
@@ -278,6 +278,11 @@ class TestQIandGS(MigrationTest):
         from plone.app.upgrade.v43.final import \
             markProductsInstalledForUninstallableProfiles
 
+        qi = getToolByName(self.portal, 'portal_quickinstaller', None)
+        if qi is None:
+            # Newer Plone without qi.
+            return
+
         # Register a profile.
         product_id = 'my.test.package'
         profile_id = '{0}:default'.format(product_id)
@@ -299,7 +304,6 @@ class TestQIandGS(MigrationTest):
         setup = getToolByName(self.portal, 'portal_setup')
         self.assertEqual(
             setup.getLastVersionForProfile(profile_id), 'unknown')
-        qi = getToolByName(self.portal, 'portal_quickinstaller')
         self.assertFalse(qi.isProductInstalled(product_id))
 
         # Call our upgrade function.  This should have no effect,
@@ -321,7 +325,10 @@ class TestQIandGS(MigrationTest):
 
     def testCleanupUninstalledProducts(self):
         from plone.app.upgrade.v43.final import cleanupUninstalledProducts
-        qi = getToolByName(self.portal, 'portal_quickinstaller')
+        qi = getToolByName(self.portal, 'portal_quickinstaller', None)
+        if qi is None:
+            # Newer Plone without qi.
+            return
         setup = getToolByName(self.portal, 'portal_setup')
         # Register three profiles.  I wanted to take 'new' as product
         # id, but there is already a python module 'new', so that goes

--- a/plone/app/upgrade/v50/alphas.py
+++ b/plone/app/upgrade/v50/alphas.py
@@ -49,7 +49,13 @@ def to50alpha1(context):
     migrate_registry_settings(portal)
 
     # install plone.app.event
-    qi = getToolByName(portal, 'portal_quickinstaller')
+    try:
+        from Products.CMFPlone.utils import get_installer
+    except ImportError:
+        # BBB For Plone 5.0 and lower.
+        qi = getToolByName(portal, 'portal_quickinstaller')
+    else:
+        qi = get_installer(portal)
     if not qi.isProductInstalled('plone.app.event'):
         qi.installProduct('plone.app.event')
 

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -349,9 +349,17 @@ def to50rc1(context):
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v50:to50rc1')
     portal = getSite()
     # install plone.app.linkintegrity and its dependencies
-    qi = getToolByName(portal, 'portal_quickinstaller')
-    if not qi.isProductInstalled('plone.app.linkintegrity'):
-        qi.installProduct('plone.app.linkintegrity')
+    try:
+        from Products.CMFPlone.utils import get_installer
+    except ImportError:
+        # BBB For Plone 5.0 and lower.
+        qi = getToolByName(portal, 'portal_quickinstaller')
+        if not qi.isProductInstalled('plone.app.linkintegrity'):
+            qi.installProduct('plone.app.linkintegrity')
+    else:
+        qi = get_installer(portal)
+        if not qi.is_product_installed('plone.app.linkintegrity'):
+            qi.install_product('plone.app.linkintegrity')
     migrate_linkintegrity_relations(portal)
 
     upgrade_usergroups_controlpanel_settings(context)


### PR DESCRIPTION
We can use get_installer in Plone 5.1 migrations. In earlier version we will keep using the portal_quickinstaller, because get_installer is not available.

In a getToolByName call for portal_quickinstaller, we will pass a default of None, so an upgrade can still work if the portal tool has already been removed.

In shared utility and base code, we will try to import get_installer, and fall back on the previous implementation.

From [PLIP 1340](https://github.com/plone/Products.CMFPlone/issues/1340)