### PR TITLE
Install plone.resource in Plone 5.0 alpha 3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,12 @@ New features:
 
 Bug fixes:
 
+- Install plone.resource in Plone 5.0 alpha 3.  Fixes possible
+  ``TypeError: argument of type 'NoneType' is not iterable`` when
+  migrating from Plone 4.3 for a site that did not have plone.resource
+  or diazo installed yet.
+  Fixes `issue 1756 <https://github.com/plone/Products.CMFPlone/issues/1756>`_. [maurits]
+
 - Be sure smtp_port is an integer.
   [ale-rt]
 

--- a/plone/app/upgrade/v50/profiles/to_alpha3/metadata.xml
+++ b/plone/app/upgrade/v50/profiles/to_alpha3/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>1000</version>
+  <dependencies>
+    <dependency>profile-plone.resource:default</dependency>
+  </dependencies>
+</metadata>


### PR DESCRIPTION
Fixes possible ``TypeError: argument of type 'NoneType' is not iterable`` when migrating from Plone 4.3 for a site that did not have plone.resource or diazo installed yet.

Fixes https://github.com/plone/Products.CMFPlone/issues/1756