### PR TITLE
Don't remove sub skin layers when cleaning `portal_skins`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,12 @@ New features:
 
 Bug fixes:
 
+- Don't remove sub skin layers when cleaning ``portal_skins``.
+  Created ``utils.cleanUpSkinsTool`` method which has generally useful
+  code for cleaning up the skins.
+  Fixes `issue 87 <https://github.com/plone/plone.app.upgrade/issues/87>`_.
+  [maurits]
+
 - Install plone.resource in Plone 5.0 alpha 3.  Fixes possible
   ``TypeError: argument of type 'NoneType' is not iterable`` when
   migrating from Plone 4.3 for a site that did not have plone.resource

--- a/plone/app/upgrade/tests/skin_test/README.txt
+++ b/plone/app/upgrade/tests/skin_test/README.txt
@@ -1,0 +1,1 @@
+Recursive skin

--- a/plone/app/upgrade/tests/skin_test/sub1/README.txt
+++ b/plone/app/upgrade/tests/skin_test/sub1/README.txt
@@ -1,0 +1,1 @@
+Recursive sub skin 1

--- a/plone/app/upgrade/tests/skin_test/sub1/subsub1/README.txt
+++ b/plone/app/upgrade/tests/skin_test/sub1/subsub1/README.txt
@@ -1,0 +1,1 @@
+Recursive sub sub skin 1

--- a/plone/app/upgrade/tests/skin_test/sub2/README.txt
+++ b/plone/app/upgrade/tests/skin_test/sub2/README.txt
@@ -1,0 +1,1 @@
+Recursive sub skin 2

--- a/plone/app/upgrade/tests/test_utils.py
+++ b/plone/app/upgrade/tests/test_utils.py
@@ -1,0 +1,73 @@
+from Products.CMFCore.utils import getToolByName
+from plone.app.upgrade.tests.base import MigrationTest
+from plone.app.upgrade import utils
+
+
+class TestUtils(MigrationTest):
+
+    def testCleanUpSkinsTool(self):
+        # This removes no longer existing layers from the skins tool and the
+        # skin selections.
+        from Products.CMFCore.DirectoryView import DirectoryView
+        from Products.CMFCore.DirectoryView import registerDirectory
+        self.setRoles(['Manager'])
+        skins = getToolByName(self.portal, 'portal_skins')
+        existing = skins.keys()
+        selection = 'Plone Default'
+
+        def layers_in_selection(selection_name):
+            return skins.getSkinPath(selection_name).split(',')
+
+        existing_layers_in_selection = layers_in_selection(selection)
+
+        # An initial cleanup should do nothing.
+        utils.cleanUpSkinsTool(self.portal)
+        self.assertEqual(len(skins.keys()), len(existing))
+        self.assertEqual(len(layers_in_selection(selection)),
+                         len(existing_layers_in_selection))
+
+        # A second cleanup should also do nothing.  We used to rename
+        # plone_styles to classic_styles on the first run, which would get
+        # removed on a second run because in these tests the class_styles layer
+        # is not available.
+        utils.cleanUpSkinsTool(self.portal)
+        self.assertEqual(len(skins.keys()), len(existing))
+        self.assertEqual(len(layers_in_selection(selection)),
+                         len(existing_layers_in_selection))
+
+        # Register some test skins layers.  Note: the current module name is
+        # taken from globals()['__name__'], which is how registerDirectory
+        # knows where to find the directory.  Also note that you should not try
+        # to register any layer that is outside of the current directory or in
+        # a 'skins' sub directory.  There is just too much crazyness in the
+        # api.  Better try to load some zcml in that case.
+        skin_name = 'skin_test'
+        # Make it available for Zope.  This is what you would do in zcml.
+        registerDirectory(skin_name, globals(), subdirs=1)
+        # Add the DirectoryView object to portal_skins.
+        directory_info = DirectoryView(
+            skin_name, reg_key='plone.app.upgrade.tests:%s' % skin_name)
+        skins._setObject(skin_name, directory_info)
+
+        # Add its sub skins to a skin selection.
+        self.addSkinLayer('skin_test/sub1', skin=selection)
+        self.addSkinLayer('skin_test/sub1/subsub1', skin=selection)
+        self.addSkinLayer('skin_test/sub2', skin=selection)
+
+        # Did that work?
+        self.assertEqual(len(skins.keys()), len(existing) + 1)
+        self.assertEqual(len(layers_in_selection(selection)),
+                         len(existing_layers_in_selection) + 3)
+
+        # Clean it up again.  Nothing should be removed.
+        utils.cleanUpSkinsTool(self.portal)
+        self.assertEqual(len(skins.keys()), len(existing) + 1)
+        self.assertEqual(len(layers_in_selection(selection)),
+                         len(existing_layers_in_selection) + 3)
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestUtils))
+    return suite

--- a/plone/app/upgrade/v43/configure.zcml
+++ b/plone/app/upgrade/v43/configure.zcml
@@ -221,7 +221,7 @@
 
         <genericsetup:upgradeStep
             title="Cleanup the skins tool."
-            handler="plone.app.upgrade.v40.alphas.cleanUpSkinsTool"
+            handler="plone.app.upgrade.utils.cleanUpSkinsTool"
             />
 
         <genericsetup:upgradeStep

--- a/plone/app/upgrade/v50/configure.zcml
+++ b/plone/app/upgrade/v50/configure.zcml
@@ -256,7 +256,7 @@
 
        <gs:upgradeStep
            title="Cleanup the skins tool."
-           handler="plone.app.upgrade.v40.alphas.cleanUpSkinsTool"
+           handler="plone.app.upgrade.utils.cleanUpSkinsTool"
            />
 
        <gs:upgradeStep


### PR DESCRIPTION
Created `utils.cleanUpSkinsTool` method which has generally useful code for cleaning up the skins.

Fixes https://github.com/plone/plone.app.upgrade/issues/87