### PR TITLE
Remove jquery.cookie from stub_js_modules.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ Breaking changes:
 
 New features:
 
+- Remove jquery.cookie from plone-logged-in bundle's stub_js_modules.
+  The toolbar, which has a dependency on jquery.cookie,
+  was moved from the plone bundle to plone-logged-in in CMPlone 5.1a2.
+  [thet]
+
 - Products.MimetypesRegistry has no longer a skins layer, remove it.
   [jensens]
 

--- a/plone/app/upgrade/v51/betas.py
+++ b/plone/app/upgrade/v51/betas.py
@@ -52,3 +52,21 @@ def remove_leftover_skin_layers(context):
     """Products.MimetypesRegistry no longer has a skin layer, remove it.
     """
     cleanUpSkinsTool(context)
+
+
+def remove_jquery_cookie_from_stub_js_modules(context):
+    """Remove jquery.cookie from plone-logged-in bundle's stub_js_modules.
+    The toolbar, which has a dependency on jquery.cookie, was moved from the
+    plone bundle to plone-logged-in in CMPlone 5.1a2.
+    """
+    registry = getUtility(IRegistry)
+
+    import pdb
+    pdb.set_trace()
+
+    reg_key = 'plone.bundles/plone-logged-in.stub_js_modules'
+
+    value = registry.get(reg_key, [])
+    if 'jquery.cookie' in value:
+        value.remove('jquery.cookie')
+        registry[reg_key] = value

--- a/plone/app/upgrade/v51/betas.py
+++ b/plone/app/upgrade/v51/betas.py
@@ -60,12 +60,7 @@ def remove_jquery_cookie_from_stub_js_modules(context):
     plone bundle to plone-logged-in in CMPlone 5.1a2.
     """
     registry = getUtility(IRegistry)
-
-    import pdb
-    pdb.set_trace()
-
     reg_key = 'plone.bundles/plone-logged-in.stub_js_modules'
-
     value = registry.get(reg_key, [])
     if 'jquery.cookie' in value:
         value.remove('jquery.cookie')

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -63,6 +63,16 @@ Add new Mockup 2.4.0 relateditems resource url.
            handler=".betas.remove_leftover_skin_layers"
            />
 
+      <gs:upgradeStep
+           title="Remove jquery.cookie from plone-logged-in stub_js_modules"
+           description="
+Remove jquery.cookie from plone-logged-in bundle's stub_js_modules.
+The toolbar, which has a dependency on jquery.cookie,
+was moved from the plone bundle to plone-logged-in in CMPlone 5.1a2.
+           "
+           handler=".betas.remove_jquery_cookie_from_stub_js_modules"
+           />
+
     </gs:upgradeSteps>
 
 </configure>

--- a/plone/app/upgrade/v51/profiles/to_beta1/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_beta1/registry.xml
@@ -17,4 +17,5 @@
   <!-- Add sort_on field to search controlpanel -->
   <records interface="Products.CMFPlone.interfaces.ISearchSchema"
            prefix="plone" />
+
 </registry>


### PR DESCRIPTION
Remove jquery.cookie from plone-logged-in bundle's stub_js_modules.
The toolbar, which has a dependency on jquery.cookie, was moved from the plone bundle to plone-logged-in in CMPlone 5.1a2.