### PR TITLE
Enabled update from latest 4.3, revision 4315 instead of 4310.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,10 @@ New features:
 
 Bug fixes:
 
+- Enabled update from latest 4.3 profile revision.
+  Otherwise we would skip a few upgrade steps when migrating to
+  Plone 5.  [maurits]
+
 - Don't remove sub skin layers when cleaning ``portal_skins``.
   Created ``utils.cleanUpSkinsTool`` method which has generally useful
   code for cleaning up the skins.

--- a/plone/app/upgrade/v50/configure.zcml
+++ b/plone/app/upgrade/v50/configure.zcml
@@ -6,8 +6,12 @@
 
     <include file="profiles.zcml" />
 
+    <!-- Upgrade from latest 4.3 profile revision.  This source step
+         does not need to exist, it just needs to be higher than other
+         4.3 profile revisions.  GenericSetup will then sort it nicely
+         for us. -->
     <gs:upgradeSteps
-        source="4310"
+        source="4399"
         destination="5000"
         profile="Products.CMFPlone:plone">
 


### PR DESCRIPTION
Otherwise we would skip a few upgrade steps when migrating to Plone 5.

This is actually NOT related to the recent split into branch 1.x, but should have been done long ago.