### PR TITLE
Fix several 50 upgrade steps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,10 @@ New features:
 
 Bug fixes:
 
+- Install plone.app.theming in 5.0 alpha.
+  When it is already installed, upgrade it.
+  [maurits]
+
 - Fixed AttributeError ``use_content_negotiation`` when migrating old language tool.
   Not all versions have the same properties available.
   Now we only take over existing properties.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,12 @@ New features:
 
 Bug fixes:
 
+- Fixed AttributeError ``use_content_negotiation`` when migrating old language tool.
+  Not all versions have the same properties available.
+  Now we only take over existing properties.
+  5.0 beta.
+  [maurits]
+
 - Fixed ConstraintNotSatisfied when default_editor is not allowed.
   5.0 alpha.
   [maurits]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,10 @@ New features:
 
 Bug fixes:
 
+- Fixed ConstraintNotSatisfied when default_editor is not allowed.
+  5.0 alpha.
+  [maurits]
+
 - Enabled update from latest 4.3 profile revision.
   Otherwise we would skip a few upgrade steps when migrating to
   Plone 5.  [maurits]

--- a/plone/app/upgrade/v50/alphas.py
+++ b/plone/app/upgrade/v50/alphas.py
@@ -8,6 +8,7 @@ from Products.CMFPlone.interfaces import IMaintenanceSchema
 from Products.CMFPlone.interfaces import INavigationSchema
 from Products.CMFPlone.interfaces import ISearchSchema
 from Products.CMFPlone.interfaces import ISiteSchema
+from plone.app.theming.interfaces import IThemeSettings
 from plone.app.upgrade.utils import loadMigrationProfile
 from plone.app.upgrade.utils import get_property
 from plone.app.upgrade.v40.alphas import cleanUpToolRegistry
@@ -70,6 +71,25 @@ def to50alpha1(context):
             qi.installProduct('plonetheme.barceloneta')
 
     upgrade_keyring(context)
+    installOrUpgradePloneAppTheming(context)
+
+
+def installOrUpgradePloneAppTheming(context):
+    """Install plone.app.theming if not installed yet.
+
+    Upgrade it for good measure if it is already installed.
+    """
+    profile_id = 'profile-plone.app.theming:default'
+    portal_setup = getToolByName(context, 'portal_setup')
+    registry = getUtility(IRegistry)
+    try:
+        registry.forInterface(IThemeSettings)
+    except KeyError:
+        # plone.app.theming not yet installed
+        portal_setup.runAllImportStepsFromProfile(profile_id)
+    else:
+        # Might as well upgrade it if needed.
+        portal_setup.upgradeProfile(profile_id)
 
 
 def lowercase_email_login(context):

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -78,10 +78,6 @@ def upgrade_portal_language(context):
         # Remove the old tool
         portal.manage_delObjects('portal_languages')
 
-    # TODO: Remove portal skin
-    # <object name="LanguageTool" meta_type="Filesystem Directory View"
-    # directory="Products.PloneLanguageTool:skins/LanguageTool"/>
-
 
 def upgrade_mail_controlpanel_settings(context):
     registry = getUtility(IRegistry)

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -22,6 +22,23 @@ import logging
 
 logger = logging.getLogger('plone.app.upgrade')
 
+# Mapping of old portal_languages option to new language settings option.
+LANGUAGE_OPTION_MAPPING = {
+    # 'old': 'new',
+    'always_show_selector': 'always_show_selector',
+    'authenticated_users_only': 'authenticated_users_only',
+    'display_flags': 'display_flags',
+    'set_cookie_everywhere': 'set_cookie_always',  # different
+    'supported_langs': 'available_languages',  # different
+    'use_cctld_negotiation': 'use_cctld_negotiation',
+    'use_combined_language_codes': 'use_combined_language_codes',
+    'use_content_negotiation': 'use_content_negotiation',
+    'use_cookie_negotiation': 'use_cookie_negotiation',
+    'use_path_negotiation': 'use_path_negotiation',
+    'use_request_negotiation': 'use_request_negotiation',
+    'use_subdomain_negotiation': 'use_subdomain_negotiation',
+}
+
 
 def to50beta1(context):
     """5.0alpha3 -> 5.0beta1"""
@@ -55,23 +72,9 @@ def upgrade_portal_language(context):
     lang_settings.default_language = default_lang
     if hasattr(portal, 'portal_languages'):
         portal_languages = getSite().portal_languages
-        lang_settings.available_languages = portal_languages.supported_langs
-
-        lang_settings.use_combined_language_codes = portal_languages.use_combined_language_codes  # noqa
-        lang_settings.display_flags = portal_languages.display_flags
-
-        lang_settings.use_path_negotiation = portal_languages.use_path_negotiation  # noqa
-        lang_settings.use_content_negotiation = portal_languages.use_content_negotiation  # noqa
-        lang_settings.use_cookie_negotiation = portal_languages.use_cookie_negotiation  # noqa
-        if hasattr(portal_languages, 'set_cookie_everywhere'):
-            lang_settings.set_cookie_always = portal_languages.set_cookie_everywhere  # noqa
-        lang_settings.authenticated_users_only = portal_languages.authenticated_users_only  # noqa
-        lang_settings.use_request_negotiation = portal_languages.use_request_negotiation  # noqa
-        lang_settings.use_cctld_negotiation = portal_languages.use_cctld_negotiation  # noqa
-        lang_settings.use_subdomain_negotiation = portal_languages.use_subdomain_negotiation  # noqa
-        if hasattr(portal_languages, 'always_show_selector'):
-            lang_settings.always_show_selector = portal_languages.always_show_selector  # noqa
-
+        for old, new in LANGUAGE_OPTION_MAPPING.items():
+            if hasattr(portal_languages, old):
+                setattr(lang_settings, new, getattr(portal_languages, old))
         # Remove the old tool
         portal.manage_delObjects('portal_languages')
 


### PR DESCRIPTION
I encountered several problems trying an upgrade to Plone 5.0.6 today. This fixes them:
- ConstraintNotSatisfied in default_editor (a variant of https://github.com/plone/plone.app.upgrade/pull/81)
- AttributeError for use_content_negatiation
- install plone.app.theming. Part of https://github.com/plone/Products.CMFPlone/issues/1306