### PR TITLE
Install plone.app.caching in 5.0 alpha, if available.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,10 @@ New features:
 
 Bug fixes:
 
+- Install plone.app.caching in 5.0 alpha if available.
+  When it is already installed, upgrade it.
+  [maurits]
+
 - Install plone.app.theming in 5.0 alpha.
   When it is already installed, upgrade it.
   [maurits]

--- a/plone/app/upgrade/v50/testing.py
+++ b/plone/app/upgrade/v50/testing.py
@@ -2,11 +2,23 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import PLONE_FIXTURE
 from plone.testing.z2 import FunctionalTesting, login
 from zope.component.hooks import setSite
+from zope.configuration import xmlconfig
 import os
 
 
 class RealUpgradeLayer(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE,)
+
+    def setUpZope(self, app, configurationContext):
+        # load ZCML
+        # In 5.0 alpha we install or upgrade plone.app.caching,
+        # so it must be available to Zope..
+        import plone.app.caching
+        xmlconfig.file(
+            'configure.zcml',
+            plone.app.caching,
+            context=configurationContext
+        )
 
     def setUpPloneSite(self, portal):
         app = portal.aq_parent

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         test=[
             'zope.site',
             'mock',
+            'plone.app.caching',
             'plone.app.testing',
             'plone.app.theming',
         ]


### PR DESCRIPTION
When it is already installed, upgrade it.

Note that plone.app.caching is required by Plone, not by Products.CMFPlone, so it may not be available for installing.

See https://github.com/plone/Products.CMFPlone/issues/1306#issuecomment-258551451