### PR TITLE
fix move_pw_reset_tool upgrade step, we’re just using the old value again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ New features:
 
 Bug fixes:
 
+- Fix move_pw_reset_tool upgrade step
+  [agitator]
+
 - Install plone.app.caching in 5.0 alpha if available.
   When it is already installed, upgrade it.
   [maurits]

--- a/plone/app/upgrade/v51/betas.py
+++ b/plone/app/upgrade/v51/betas.py
@@ -84,6 +84,8 @@ def move_pw_reset_tool(context):
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v51:to51beta1')
     pw_reset_tool = getToolByName(context, 'portal_password_reset')
     if old_days_timeout is not _marker:
-        pw_reset_tool._timedelta = int(old_days_timeout / 24)
+        if old_days_timeout < 1:
+            old_days_timeout = 7
+        pw_reset_tool._timedelta = int(old_days_timeout)
     if old_user_check is not _marker:
         pw_reset_tool._user_check = bool(old_user_check)


### PR DESCRIPTION
closes https://github.com/plone/Products.CMFPlone/issues/1849 