### PR TITLE
Remove displayContentsTab from action expressions in 5.1.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,10 @@ New features:
 
 Bug fixes:
 
+- Remove displayContentsTab from action expressions in 5.1.
+  Fixes https://github.com/plone/Products.CMFPlone/issues/1935.
+  [maurits]
+
 - Fix move_pw_reset_tool upgrade step
   [agitator]
 

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -87,6 +87,11 @@ was moved from the plone bundle to plone-logged-in in CMPlone 5.1a2.
            handler=".betas.move_pw_reset_tool"
            />
 
+      <gs:upgradeStep
+           title="Remove displayContentsTab from action expressions"
+           handler=".betas.remove_displayContentsTab_from_action_expressions"
+           />
+
     </gs:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/1935.