### PR TITLE
Update social media field values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Update ``twitter_username``, ``facebook_app_id`` and ``facebook_username`` field values as they are now declared as ``ASCIILine`` instead of ``TextLine``.
+  [hvelarde]
 
 
 2.0.1 (2017-03-09)

--- a/plone/app/upgrade/v51/betas.py
+++ b/plone/app/upgrade/v51/betas.py
@@ -117,3 +117,17 @@ def remove_displayContentsTab_from_action_expressions(context):
         logger.warn('Action at %s references removed script %s in available. '
                     'expression %r. Please change it',
                     path, text, ac.available_expr)
+
+
+def update_social_media_fields(context):
+    """Update twitter_username, facebook_app_id and facebook_username
+    field values as they are now declared as ASCIILine instead of
+    TextLine.
+    """
+    from Products.CMFPlone.interfaces.controlpanel import ISocialMediaSchema
+    registry = getUtility(IRegistry)
+    settings = registry.forInterface(ISocialMediaSchema, prefix='plone')
+    settings.twitter_username = str(settings.twitter_username)
+    settings.facebook_app_id = str(settings.facebook_app_id)
+    settings.facebook_username = str(settings.facebook_username)
+    logger.log(logging.INFO, 'Field types updated on social media schema')

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -123,7 +123,7 @@ Add image scaling options to image handling control panel.
         <gs:upgradeStep
             title="Update social media fields"
             description=""
-            handler="betas.update_social_media_fields"
+            handler=".betas.update_social_media_fields"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -120,6 +120,12 @@ Add image scaling options to image handling control panel.
             import_profile="plone.app.upgrade.v51:to51beta3"
             />
 
+        <gs:upgradeStep
+            title="Update social media fields"
+            description=""
+            handler="betas.update_social_media_fields"
+            />
+
     </gs:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
`twitter_username`, `facebook_app_id` and `facebook_username` are now declared as `ASCIILine` instead of `TextLine`.

refs. https://github.com/plone/Products.CMFPlone/pull/1967