### PR TITLE
Fixed title and description of plone.resource.maxage.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed title and description of plone.resource.maxage.
+  This had the title and description from shared maxage,
+  due to a wrong reference.
+  See https://github.com/plone/Products.CMFPlone/issues/1989
+  [maurits]
 
 
 2.0.2 (2017-04-03)

--- a/plone/app/upgrade/v50/configure.zcml
+++ b/plone/app/upgrade/v50/configure.zcml
@@ -345,11 +345,10 @@
         destination="5018"
         profile="Products.CMFPlone:plone">
 
-        <gs:upgradeStep
-            title="Miscellaneous"
-            description=""
-            handler="..utils.null_upgrade_step"
-            />
+      <gs:upgradeStep
+          title="Fix double shared maxage"
+          handler=".final.fix_double_smaxage"
+          />
 
     </gs:upgradeSteps>
 

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -134,9 +134,8 @@ Add image scaling options to image handling control panel.
         profile="Products.CMFPlone:plone">
 
         <gs:upgradeStep
-            title="Miscellaneous"
-            description=""
-            handler="..utils.null_upgrade_step"
+            title="Fix double shared maxage"
+            handler="..v50.final.fix_double_smaxage"
             />
 
     </gs:upgradeSteps>


### PR DESCRIPTION
This had the title and description from shared maxage, due to a wrong reference.
See https://github.com/plone/Products.CMFPlone/issues/1989

This is run when upgrading to Plone 5.0.8 and 5.1b4.