### PR TITLE
Fixed ImportError when `Products.ATContentTypes` is not available.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Fixed ImportError when ``Products.ATContentTypes`` is not available.
+  This happens when you only have the ``Products.CMFPlone`` egg
+  and not the ``Plone`` egg.  [maurits]
+
 - Fixed title and description of plone.resource.maxage.
   This had the title and description from shared maxage,
   due to a wrong reference.

--- a/plone/app/upgrade/__init__.py
+++ b/plone/app/upgrade/__init__.py
@@ -108,8 +108,14 @@ try:
     import Products.CMFDefault.MetadataTool
     Products.CMFDefault.MetadataTool  # pyflakes
 except ImportError:
-    from Products.ATContentTypes.tool import metadata
-    sys.modules['Products.CMFDefault.MetadataTool'] = metadata
+    try:
+        pkg_resources.get_distribution('Products.ATContentTypes')
+    except:
+        from plone.app.upgrade import atcontentypes_bbb
+        alias_module('Products.CMFDefault.MetadataTool', atcontentypes_bbb)
+    else:
+        from Products.ATContentTypes.tool import metadata
+        sys.modules['Products.CMFDefault.MetadataTool'] = metadata
 
 try:
     import Products.CMFDefault.SyndicationInfo

--- a/plone/app/upgrade/v40/alphas.py
+++ b/plone/app/upgrade/v40/alphas.py
@@ -599,3 +599,19 @@ def installNewModifiers(context):
     if modifiers is not None:
         install(modifiers)
         logger.info('Added new CMFEditions modifiers.')
+
+
+def run_upgrade_dcmi_metadata(tool):
+    """Run the upgrade_dcmi_metadata step from CMFDefault.
+
+    This is only run if CMFDefault is 'installed' (importable).
+    But in Plone 5 it may still be there as aliased module,
+    missing the upgrade module.  So we have a small wrapper around it,
+    to avoid an ImportError on startup.
+    """
+    try:
+        from Products.CMFDefault.upgrade.to22 import upgrade_dcmi_metadata
+    except ImportError:
+        logger.info('Original CMFDefault DCMI upgrade step not available.')
+        return
+    upgrade_dcmi_metadata(tool)

--- a/plone/app/upgrade/v40/configure.zcml
+++ b/plone/app/upgrade/v40/configure.zcml
@@ -172,7 +172,7 @@
         <genericsetup:upgradeStep
             zcml:condition="installed Products.CMFDefault"
             title="Upgrade DCMI metadata storage in portal_metadata"
-            handler="Products.CMFDefault.upgrade.to22.upgrade_dcmi_metadata"
+            handler=".alphas.run_upgrade_dcmi_metadata"
             />
 
         <genericsetup:upgradeStep


### PR DESCRIPTION
This happens when you only have the `Products.CMFPlone` egg and not the `Plone` egg.
See https://community.plone.org/t/plone-5-1b3-soft-released/3936/5
Traceback was:

```
  File "/home/vagrant/Eggs/plone.app.upgrade-2.0.2-py2.7.egg/plone/app/upgrade/__init__.py", line 111, in <module>
      from Products.ATContentTypes.tool import metadata
   zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/home/vagrant/www.fhnw.ch/parts/instance1v/etc/site.zcml", line 12.2-12.39
     ZopeXMLConfigurationError: File "/home/vagrant/Eggs/Products.CMFPlone-5.1b3-py2.7.egg/Products/CMFPlone/meta.zcml", line 47.4-51.10
     ImportError: No module named ATContentTypes.tool
```

I fixed that with the already available atcontenttypes_bbb module.

Then the next traceback surfaced:

```
    ZopeXMLConfigurationError: File "/Users/maurits/community/plone-coredev/5.1/src/plone.app.upgrade/plone/app/upgrade/v40/configure.zcml", line 172.8-176.14
    ConfigurationError: ('Invalid value for', 'handler', "ImportError: Couldn't import Products.CMFDefault.upgrade.to22, No module named upgrade.to22")
```

This is because my fix turned Products.CMFDefault into an aliased module,
which caused the conditionally registered upgrade step to be loaded, causing an error.
I fixed this by making a wrapper around the original CMFDefault upgrade step.

Note that this will only be called when someone upgrades from a Plone 4.0 alpha release to Plone 5, which seems unlikely.