### PR TITLE
Fixed title and description of plone.resource.maxage. [4.3]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,11 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed title and description of plone.resource.maxage.
+  This had the title and description from shared maxage,
+  due to a wrong reference.
+  See https://github.com/plone/Products.CMFPlone/issues/1989
+  [maurits]
 
 
 1.4.1 (2017-03-16)

--- a/plone/app/upgrade/v43/configure.zcml
+++ b/plone/app/upgrade/v43/configure.zcml
@@ -288,11 +288,10 @@
         destination="4317"
         profile="Products.CMFPlone:plone">
 
-        <genericsetup:upgradeStep
-            title="Miscellaneous"
-            description=""
-            handler="..utils.null_upgrade_step"
-            />
+      <genericsetup:upgradeStep
+          title="Fix double shared maxage"
+          handler=".final.fix_double_smaxage"
+          />
 
     </genericsetup:upgradeSteps>
 

--- a/plone/app/upgrade/v43/final.py
+++ b/plone/app/upgrade/v43/final.py
@@ -334,3 +334,31 @@ def addSortOnProperty(context):
         site_properties.manage_addProperty('sort_on', 'relevance', 'string')
         logger.log(logging.INFO,
                    "Added 'sort_on' property to site_properties.")
+
+
+def fix_double_smaxage(context):
+    """Fix caching definition.
+
+    plone.resource.maxage has title and description from shared maxage.
+    See https://github.com/plone/Products.CMFPlone/issues/1989
+    """
+    from plone.registry.record import Record
+    from plone.registry import FieldRef
+    from plone.registry.interfaces import IRegistry
+    from zope.component import getUtility
+    registry = getUtility(IRegistry)
+    # If these three registry records are not defined,
+    # we do no fix.
+    maxage = 'plone.app.caching.strongCaching.plone.resource.maxage'
+    def_maxage = 'plone.app.caching.strongCaching.maxage'
+    def_smaxage = 'plone.app.caching.strongCaching.smaxage'
+    for name in (maxage, def_maxage, def_smaxage):
+        if name not in registry:
+            return
+    if registry.records[maxage].field.recordName != def_smaxage:
+        # no fix needed
+        return
+    field_ref = FieldRef(def_maxage, registry.records[def_maxage].field)
+    old_value = registry[maxage]
+    registry.records[maxage] = Record(field_ref, old_value)
+    logger.info('Fixed {0} to refer to {1}.'.format(maxage, def_maxage))


### PR DESCRIPTION
This had the title and description from shared maxage, due to a wrong reference.
See https://github.com/plone/Products.CMFPlone/issues/1989

Backported from master.
This needed changes in the test setup to load the plone.app.caching zcml in a layer.
And two fixes so it works on Python 2.6 too. This is why I run coredev 4.3 with Python 2.6. :-)