### PR TITLE
Fixed KeyError for render_body on syndication-controlpanel.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,12 @@ New features:
 
 Bug fixes:
 
+- Register ``ISiteSyndicationSettings`` again.
+  This interface was updated in 5.0rc3.
+  On older sites, this would cause an error on the ``syndication-controlpanel``:
+  KeyError: 'Interface `Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings` defines a field `render_body`, for which there is no record.
+  [maurits]
+
 - Catch warning the pythonic way.
   Makes it work with latest CMFCore.
   [jensens]

--- a/plone/app/upgrade/v50/configure.zcml
+++ b/plone/app/upgrade/v50/configure.zcml
@@ -350,6 +350,11 @@
           handler=".final.fix_double_smaxage"
           />
 
+      <gs:upgradeDepends
+           title="Run to508 upgrade profile."
+           import_profile="plone.app.upgrade.v50:to508"
+           />
+
     </gs:upgradeSteps>
 
 </configure>

--- a/plone/app/upgrade/v50/profiles.zcml
+++ b/plone/app/upgrade/v50/profiles.zcml
@@ -120,4 +120,13 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:registerProfile
+      name="to508"
+      title="Upgrade profile for Plone 5.0.7 to Plone 5.0.8"
+      description=""
+      directory="profiles/to_508"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
 </configure>

--- a/plone/app/upgrade/v50/profiles/to_508/registry.xml
+++ b/plone/app/upgrade/v50/profiles/to_508/registry.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<registry>
+  <!-- add missing render_body field -->
+  <records interface="Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings" />
+</registry>

--- a/plone/app/upgrade/v51/profiles/to_beta4/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_beta4/registry.xml
@@ -22,9 +22,12 @@
   </records>
 
   <!-- Remove TinyMCE layer resource -->
-  <records 
+  <records
       remove="True"
       prefix="plone.resources/tinymce-layer"
       interface='Products.CMFPlone.interfaces.IResourceRegistry'/>
+
+  <!-- add missing render_body field -->
+  <records interface="Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings" />
 
 </registry>


### PR DESCRIPTION
This happens on a site created before 5.0rc3. When you access the syndication control panel on 5.0.7, you get this error:

```
ERROR Zope.SiteErrorLog 1496047363.110.0871358599389 http://127.0.0.1:8080/Zest/@@syndication-controlpanel
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module plone.z3cform.layout, line 66, in __call__
  Module plone.z3cform.layout, line 50, in update
  Module Products.CMFPlone.controlpanel.browser.syndication, line 51, in update
  Module plone.z3cform.fieldsets.extensible, line 59, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 132, in update
  Module z3c.form.form, line 129, in updateWidgets
  Module plone.app.registry.browser.controlpanel, line 50, in getContent
  Module plone.registry.registry, line 78, in forInterface
KeyError: 'Interface `Products.CMFPlone.interfaces.syndication.ISiteSyndicationSettings` defines a field `render_body`, for which there is no record.'
```