### PR TITLE
Plone 5.1: Fixup timezone record fields, as old interface plone.app.e…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Plone 5.1: Fixup timezone record fields, as old interface plone.app.event.bbb.interfaces.IDateAndTimeSchema is gone since plone.app.event 3.0.2.
+  [thet]
+
 - Fix upgrade step for ISocialMediaSchema
   [MrTango]
 

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -135,7 +135,8 @@ Add image scaling options to image handling control panel.
 
         <gs:upgradeDepends
             title="Run to51beta4 upgrade profile."
-            description="Add options for icon- and thumb-handling to Site control panel.
+            description="Fixup timezone record fields, as old interface plone.app.event.bbb.interfaces.IDateAndTimeSchema is gone since plone.app.event 3.0.2.
+                         Add options for icon- and thumb-handling to Site control panel.
                          New metadata column `mime_type`.
                          Update plone-logged-in bundle.
                          TinyMCE 4.5.6 update.

--- a/plone/app/upgrade/v51/profiles/to_beta4/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_beta4/registry.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0"?>
 <registry>
-<!-- New options for thumb- and icon-handling -->
-    <records interface="Products.CMFPlone.interfaces.ISiteSchema"
-            prefix="plone" />
+
+  <!-- Fixup timezone record fields, as old interface plone.app.event.bbb.interfaces.IDateAndTimeSchema is gone since plone.app.event 3.0.2. -->
+  <records interface="Products.CMFPlone.interfaces.IDateAndTimeSchema" prefix="plone" />
+
+  <!-- New options for thumb- and icon-handling -->
+  <records interface="Products.CMFPlone.interfaces.ISiteSchema" prefix="plone" />
 
   <!-- Update ``last_compilation`` to deliver new bundles -->
   <records


### PR DESCRIPTION
…vent.bbb.interfaces.IDateAndTimeSchema is gone since plone.app.event 3.0.2.