### PR TITLE
Register settings for safe_html-Transform 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Register settings for safe_html-Transform before linkintegrity-migration in 5.0rc1
+  [pbauer]
 
 
 2.0.6 (2017-08-05)


### PR DESCRIPTION
before linkintegrity-migration in 5.0rc1

Fixes https://github.com/plone/Products.CMFPlone/issues/2129