### PR TITLE
Register safe_html-Transform settings when migrating from 5107 to 5108 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Register settings for safe_html-Transform when migrating from 5107 to 5108
+  [pbauer]
 
 
 2.0.7 (2017-09-10)

--- a/plone/app/upgrade/v51/betas.py
+++ b/plone/app/upgrade/v51/betas.py
@@ -185,7 +185,12 @@ def move_safe_html_settings_to_registry(context):
     """ Move safe_html settings from portal_transforms to Plone registry.
     """
     registry = getUtility(IRegistry)
-    settings = registry.forInterface(IFilterSchema, prefix='plone')
+    try:
+        settings = registry.forInterface(IFilterSchema, prefix='plone')
+    except KeyError:
+        # Catch case where valid_tags is not yet registered
+        registry.registerInterface(IFilterSchema, prefix='plone')
+        settings = registry.forInterface(IFilterSchema, prefix='plone')
     pt = getToolByName(context, 'portal_transforms')
     disable_filtering = pt.safe_html._config.get('disable_transform')
     raw_valid_tags = pt.safe_html._config.get('valid_tags') or {}


### PR DESCRIPTION
Fixes the following during upgrade from 5.0.9 to 5.1rc1

```
2017-09-11 09:02:21 INFO plone.app.upgrade Ran upgrade step: Run to51beta5 upgrade profile.
2017-09-11 09:02:21 ERROR plone.app.upgrade Upgrade aborted. Error:
Traceback (most recent call last):
  File "/Users/pbauer/.cache/buildout/eggs/Products.CMFPlone-5.1rc1-py2.7.egg/Products/CMFPlone/MigrationTool.py", line 268, in upgrade
    step['step'].doStep(setup)
  File "/Users/pbauer/.cache/buildout/eggs/Products.GenericSetup-1.8.8-py2.7.egg/Products/GenericSetup/upgrade.py", line 166, in doStep
    self.handler(tool)
  File "/Users/pbauer/.cache/buildout/eggs/plone.app.upgrade-2.0.7-py2.7.egg/plone/app/upgrade/v51/betas.py", line 188, in move_safe_html_settings_to_registry
    settings = registry.forInterface(IFilterSchema, prefix='plone')
  File "/Users/pbauer/.cache/buildout/eggs/plone.registry-1.1.2-py2.7.egg/plone/registry/registry.py", line 82, in forInterface
    name
KeyError: 'Interface `Products.CMFPlone.interfaces.controlpanel.IFilterSchema` defines a field `valid_tags`, for which there is no record.'
```