### PR TITLE
Use str() when migrating checkout_workflow_policy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Bug fixes:
 - Register settings for safe_html-Transform when migrating from 5107 to 5108
   [pbauer]
 
+- Use str() when migrating checkout_workflow_policy since the field is ASCII.
+  See discussion at https://github.com/plone/plone.app.iterate/pull/53
+  [pbauer]
 
 2.0.7 (2017-09-10)
 ------------------

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -570,7 +570,7 @@ def to50rc3(context):
         value = site_properties.getProperty('checkout_workflow_policy')
         from plone.app.iterate.interfaces import IIterateSettings
         settings = registry.forInterface(IIterateSettings)
-        settings.checkout_workflow_policy = safe_unicode(value)
+        settings.checkout_workflow_policy = str(value)
         site_properties._delProperty('checkout_workflow_policy')
 
     if site_properties.hasProperty('default_page_types'):


### PR DESCRIPTION
The schema-field is ASCIILine since 5.1b4. 

I'm not sure if this would break migrations from a existing 5.0.8 to a future 5.0.9. But it fixes migrations from Plone 4 to 5.1 provided we do not merge revert to TextLine with https://github.com/plone/plone.app.iterate/pull/53

Maybe the change of https://github.com/plone/plone.app.iterate/commit/a3c13406a66a262e7411c5de0b517beba9348e03 requires another upgrade-step that changes a existing unicode-value to ascii 