### PR TITLE
5.1 Upgrade + Fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Fix deletion of registry records in ``remove_duplicate_iterate_settings``
+  from the ``5108`` upgrade.
+  [thet]
+
 - Register Plone 5.1 upgrade steps.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Register Plone 5.1 upgrade steps.
+  [thet]
+
 - Register settings for safe_html-Transform when migrating from 5107 to 5108
   [pbauer]
 

--- a/plone/app/upgrade/v51/betas.py
+++ b/plone/app/upgrade/v51/betas.py
@@ -212,9 +212,10 @@ def remove_duplicate_iterate_settings(context):
     registry = getUtility(IRegistry)
     from plone.app.iterate.interfaces import IIterateSettings
     try:
-        registry.forInterface(IIterateSettings, prefix='plone')
-        del registry['plone.checkout_workflow_policy']
-        del registry['plone.enable_checkout_workflow']
+        if 'plone.checkout_workflow_policy' in registry.records:
+            del registry.records['plone.checkout_workflow_policy']
+        if 'plone.enable_checkout_workflow' in registry.records:
+            del registry.records['plone.enable_checkout_workflow']
     except KeyError:
         pass
     # Make sure the correct settings are actually initialized

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -181,4 +181,18 @@ Add image scaling options to image handling control panel.
             />
 
     </gs:upgradeSteps>
+
+    <gs:upgradeSteps
+        source="5108"
+        destination="5109"
+        profile="Products.CMFPlone:plone">
+
+        <gs:upgradeDepends
+            title="Run to51rc1 upgrade profile."
+            description=""
+            import_profile="plone.app.upgrade.v51:to51rc1"
+            />
+
+    </gs:upgradeSteps>
+
 </configure>

--- a/plone/app/upgrade/v51/profiles.zcml
+++ b/plone/app/upgrade/v51/profiles.zcml
@@ -59,4 +59,13 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:registerProfile
+      name="to51rc1"
+      title="Upgrade profile for Plone 5.1beta5 to Plone 5.1rc1"
+      description=""
+      directory="profiles/to_rc1"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
 </configure>


### PR DESCRIPTION
- Register Plone 5.1 upgrade steps
- Fix deletion of registry records in ``remove_duplicate_iterate_settings`` from the ``5108`` upgrade