### PR TITLE
Fixed WrongType exception when migrating installed Iterate to 5.0.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed WrongType exception when migrating installed Iterate to 5.0.
+  [maurits]
 
 
 2.0.8 (2017-09-25)

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -17,6 +17,7 @@ from Products.CMFPlone.interfaces.controlpanel import IImagingSchema
 from Products.CMFPlone.utils import safe_unicode
 from zope.component import getUtility
 from zope.component.hooks import getSite
+from zope.schema._bootstrapinterfaces import WrongType
 
 import logging
 import pkg_resources
@@ -570,7 +571,14 @@ def to50rc3(context):
         value = site_properties.getProperty('checkout_workflow_policy')
         from plone.app.iterate.interfaces import IIterateSettings
         settings = registry.forInterface(IIterateSettings)
-        settings.checkout_workflow_policy = str(value)
+        # Some versions of plone.app.iterate require a string here,
+        # others a unicode.  Best seems to be to try both.
+        try:
+            # plone.app.iterate 3.3.2+
+            settings.checkout_workflow_policy = str(value)
+        except WrongType:
+            # plone.app.iterate 3.3.1-
+            settings.checkout_workflow_policy = safe_unicode(value)
         site_properties._delProperty('checkout_workflow_policy')
 
     if site_properties.hasProperty('default_page_types'):


### PR DESCRIPTION
This mitigates the effects from https://github.com/plone/plone.app.upgrade/pull/136. That one worked fine when going from 4.3 directly to 5.1, but not to 5.0:

```
Traceback (most recent call last):
  File "/Users/maurits/community/plone-coredev/5.0/src/Products.CMFPlone/Products/CMFPlone/MigrationTool.py", line 268, in upgrade
    step['step'].doStep(setup)
  File "/Users/maurits/shared-eggs/Products.GenericSetup-1.8.8-py2.7.egg/Products/GenericSetup/upgrade.py", line 166, in doStep
    self.handler(tool)
  File "/Users/maurits/community/plone-coredev/5.0/src/plone.app.upgrade/plone/app/upgrade/v50/betas.py", line 573, in to50rc3
    settings.checkout_workflow_policy = str(value)
  File "/Users/maurits/shared-eggs/plone.registry-1.0.5-py2.7.egg/plone/registry/recordsproxy.py", line 49, in __setattr__
    self.__registry__[full_name] = value
  File "/Users/maurits/shared-eggs/plone.registry-1.0.5-py2.7.egg/plone/registry/registry.py", line 47, in __setitem__
    self.records[name].value = value
  File "/Users/maurits/shared-eggs/plone.registry-1.0.5-py2.7.egg/plone/registry/record.py", line 82, in _set_value
    field.validate(value)
  File "/Users/maurits/shared-eggs/zope.schema-4.4.2-py2.7.egg/zope/schema/_bootstrapfields.py", line 183, in validate
    self._validate(value)
  File "/Users/maurits/shared-eggs/zope.schema-4.4.2-py2.7.egg/zope/schema/_bootstrapfields.py", line 310, in _validate
    super(MinMaxLen, self)._validate(value)
  File "/Users/maurits/shared-eggs/zope.schema-4.4.2-py2.7.egg/zope/schema/_bootstrapfields.py", line 210, in _validate
    raise WrongType(value, self._type, self.__name__)
WrongType: ('checkout_workflow_policy', <type 'unicode'>, 'value')
```

This is because 5.0 has plone.app.iterate 3.1.x or 3.2.x, which still requires unicode here.