### PR TITLE
Fix IUserGroupsSettingsSchema upgrade

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@ Bug fixes:
 - Register upgrades for Plone 5.2
   [pbauer]
 
+- Fix installation of IUserGroupsSettingsSchema into registry for Plone 5.0rc1.
+  [davisagli]
+
+- Avoid swallowing errors during registry setting upgrades.
+  [davisagli]
+
 2.0.8 (2017-09-25)
 ------------------
 

--- a/plone/app/upgrade/v50/alphas.py
+++ b/plone/app/upgrade/v50/alphas.py
@@ -229,45 +229,36 @@ def upgrade_editing_controlpanel_settings(context):
     site_properties = portal_properties.site_properties
     # get the new registry
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(
-            IEditingSchema,
-            prefix='plone',
-        )
-    except KeyError:
-        settings = False
-    if settings:
-        # migrate the old site properties to the new registry
-        if site_properties.hasProperty('visible_ids'):
-            settings.visible_ids = site_properties.visible_ids
-        if site_properties.hasProperty('enable_link_integrity_checks'):
-            settings.enable_link_integrity_checks = \
-                site_properties.enable_link_integrity_checks
-        if site_properties.hasProperty('ext_editor'):
-            settings.ext_editor = site_properties.ext_editor
-        # settings.available_editors = site_properties.available_editors
+    settings = registry.forInterface(
+        IEditingSchema,
+        prefix='plone',
+    )
+    # migrate the old site properties to the new registry
+    if site_properties.hasProperty('visible_ids'):
+        settings.visible_ids = site_properties.visible_ids
+    if site_properties.hasProperty('enable_link_integrity_checks'):
+        settings.enable_link_integrity_checks = \
+            site_properties.enable_link_integrity_checks
+    if site_properties.hasProperty('ext_editor'):
+        settings.ext_editor = site_properties.ext_editor
+    # settings.available_editors = site_properties.available_editors
 
-        # Kupu will not be available as editor in Plone 5. Therefore we just
-        # ignore the setting.  But there may be others (like an empty string)
-        # that will give an error too.  So we validate the value.
-        try:
-            IEditingSchema['default_editor'].validate(
-                site_properties.default_editor)
-        except ConstraintNotSatisfied:
-            logger.warn('Ignoring invalid site_properties.default_editor %r.',
-                        site_properties.default_editor)
-        else:
-            settings.default_editor = site_properties.default_editor
-        settings.lock_on_ttw_edit = get_property(
-            site_properties,
-            'lock_on_ttw_edit',
-            None,
-        )
+    # Kupu will not be available as editor in Plone 5. Therefore we just
+    # ignore the setting.  But there may be others (like an empty string)
+    # that will give an error too.  So we validate the value.
+    try:
+        IEditingSchema['default_editor'].validate(
+            site_properties.default_editor)
+    except ConstraintNotSatisfied:
+        logger.warn('Ignoring invalid site_properties.default_editor %r.',
+                    site_properties.default_editor)
+    else:
+        settings.default_editor = site_properties.default_editor
+    settings.lock_on_ttw_edit = get_property(
+        site_properties,
+        'lock_on_ttw_edit',
+        None,
+    )
 
 
 def upgrade_maintenance_controlpanel_settings(context):
@@ -279,24 +270,15 @@ def upgrade_maintenance_controlpanel_settings(context):
     site_properties = portal_properties.site_properties
     # get the new registry
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(
-            IMaintenanceSchema,
-            prefix='plone',
-        )
-    except KeyError:
-        settings = False
-    if settings:
-        settings.days = get_property(
-            site_properties,
-            'number_of_days_to_keep',
-            None,
-        )
+    settings = registry.forInterface(
+        IMaintenanceSchema,
+        prefix='plone',
+    )
+    settings.days = get_property(
+        site_properties,
+        'number_of_days_to_keep',
+        None,
+    )
 
 
 def upgrade_navigation_controlpanel_settings(context):
@@ -310,40 +292,31 @@ def upgrade_navigation_controlpanel_settings(context):
     types_tool = getToolByName(context, "portal_types")
     # get the new registry
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(
-            INavigationSchema,
-            prefix='plone',
-        )
-    except KeyError:
-        settings = False
-    if settings:
-        settings.disable_folder_sections = site_properties.getProperty(
-            'disable_folder_sections')
-        settings.disable_nonfolderish_sections = site_properties.getProperty(
-            'disable_nonfolderish_sections')
-        settings.show_all_parents = navigation_properties.getProperty(
-            'showAllParents')
-        allTypes = types_tool.listContentTypes()
-        blacklist = get_property(
-            navigation_properties,
-            'metaTypesNotToList',
-            default_value=[],
-        )
-        settings.displayed_types = tuple([
-            t for t in allTypes if t not in blacklist
-            and t not in BAD_TYPES
-        ])
+    settings = registry.forInterface(
+        INavigationSchema,
+        prefix='plone',
+    )
+    settings.disable_folder_sections = site_properties.getProperty(
+        'disable_folder_sections')
+    settings.disable_nonfolderish_sections = site_properties.getProperty(
+        'disable_nonfolderish_sections')
+    settings.show_all_parents = navigation_properties.getProperty(
+        'showAllParents')
+    allTypes = types_tool.listContentTypes()
+    blacklist = get_property(
+        navigation_properties,
+        'metaTypesNotToList',
+        default_value=[],
+    )
+    settings.displayed_types = tuple([
+        t for t in allTypes if t not in blacklist
+        and t not in BAD_TYPES
+    ])
 
-        settings.enable_wf_state_filtering = navigation_properties.getProperty(
-            'enable_wf_state_filtering')
-        settings.wf_states_to_show = navigation_properties.getProperty(
-            'wf_states_to_show')
+    settings.enable_wf_state_filtering = navigation_properties.getProperty(
+        'enable_wf_state_filtering')
+    settings.wf_states_to_show = navigation_properties.getProperty(
+        'wf_states_to_show')
 
 
 def upgrade_search_controlpanel_settings(context):
@@ -356,18 +329,10 @@ def upgrade_search_controlpanel_settings(context):
     types_tool = getToolByName(context, "portal_types")
     # get the new registry
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(
-            ISearchSchema,
-            prefix='plone',
-        )
-    except KeyError:
-        settings = False
+    settings = registry.forInterface(
+        ISearchSchema,
+        prefix='plone',
+    )
 
     if site_properties.hasProperty('enable_livesearch'):
         settings.enable_livesearch = site_properties.enable_livesearch
@@ -393,18 +358,10 @@ def upgrade_site_controlpanel_settings(context):
     portal = getSite()
     # get the new registry
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(
-            ISiteSchema,
-            prefix='plone',
-        )
-    except KeyError:
-        settings = False
+    settings = registry.forInterface(
+        ISiteSchema,
+        prefix='plone',
+    )
     settings.site_title = safe_unicode(portal.title)
     webstat_js = get_property(site_properties, 'webstats_js', '')
     settings.webstats_js = safe_unicode(webstat_js)

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -51,15 +51,7 @@ def to50beta1(context):
 def upgrade_portal_language(context):
     portal = getSite()
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        lang_settings = registry.forInterface(ILanguageSchema, prefix='plone')
-    except KeyError:
-        return
+    lang_settings = registry.forInterface(ILanguageSchema, prefix='plone')
     # Get old values
 
     # Merge default language options to registry
@@ -84,15 +76,7 @@ def upgrade_portal_language(context):
 
 def upgrade_mail_controlpanel_settings(context):
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        mail_settings = registry.forInterface(IMailSchema, prefix='plone')
-    except KeyError:
-        return
+    mail_settings = registry.forInterface(IMailSchema, prefix='plone')
     portal = getSite()
 
     smtp_host = getattr(portal.MailHost, 'smtp_host', '')
@@ -125,36 +109,27 @@ def upgrade_markup_controlpanel_settings(context):
     site_properties = portal_properties.site_properties
     # get the new registry
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(
-            IMarkupSchema,
-            prefix='plone',
-        )
-    except KeyError:
-        settings = False
-    if settings:
-        settings.default_type = get_property(
-            site_properties,
-            'default_contenttype',
-            None,
-        )
+    settings = registry.forInterface(
+        IMarkupSchema,
+        prefix='plone',
+    )
+    settings.default_type = get_property(
+        site_properties,
+        'default_contenttype',
+        None,
+    )
 
-        forbidden_types = site_properties.getProperty('forbidden_contenttypes')
-        forbidden_types = list(forbidden_types) if forbidden_types else []
+    forbidden_types = site_properties.getProperty('forbidden_contenttypes')
+    forbidden_types = list(forbidden_types) if forbidden_types else []
 
-        portal_transforms = getToolByName(context, 'portal_transforms')
-        allowable_types = portal_transforms.listAvailableTextInputs()
+    portal_transforms = getToolByName(context, 'portal_transforms')
+    allowable_types = portal_transforms.listAvailableTextInputs()
 
-        settings.allowed_types = tuple([
-            _type for _type in allowable_types
-            if _type not in forbidden_types
-            and _type not in 'text/x-plone-outputfilters-html'  # removed, as in plone.app.vocabularies.types  # noqa
-        ])
+    settings.allowed_types = tuple([
+        _type for _type in allowable_types
+        if _type not in forbidden_types
+        and _type not in 'text/x-plone-outputfilters-html'  # removed, as in plone.app.vocabularies.types  # noqa
+    ])
 
 
 def upgrade_security_controlpanel_settings(context):
@@ -178,33 +153,24 @@ def upgrade_security_controlpanel_settings(context):
     # get the new registry
     registry = getUtility(IRegistry)
 
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(
-            ISecuritySchema,
-            prefix='plone',
-        )
-    except KeyError:
-        settings = False
-    if settings:
-        settings.enable_self_reg = _get_enable_self_reg()
-        validate_email = portal.getProperty('validate_email', True)
-        if validate_email:
-            settings.enable_user_pwd_choice = False
-        else:
-            settings.enable_user_pwd_choice = True
-        pmembership = getToolByName(portal, 'portal_membership')
-        settings.enable_user_folders = pmembership.getMemberareaCreationFlag()
-        settings.allow_anon_views_about = site_properties.getProperty(
-            'allowAnonymousViewAbout', False)
-        settings.use_email_as_login = site_properties.getProperty(
-            'use_email_as_login', False)
-        settings.use_uuid_as_userid = site_properties.getProperty(
-            'use_uuid_as_userid', False)
+    settings = registry.forInterface(
+        ISecuritySchema,
+        prefix='plone',
+    )
+    settings.enable_self_reg = _get_enable_self_reg()
+    validate_email = portal.getProperty('validate_email', True)
+    if validate_email:
+        settings.enable_user_pwd_choice = False
+    else:
+        settings.enable_user_pwd_choice = True
+    pmembership = getToolByName(portal, 'portal_membership')
+    settings.enable_user_folders = pmembership.getMemberareaCreationFlag()
+    settings.allow_anon_views_about = site_properties.getProperty(
+        'allowAnonymousViewAbout', False)
+    settings.use_email_as_login = site_properties.getProperty(
+        'use_email_as_login', False)
+    settings.use_uuid_as_userid = site_properties.getProperty(
+        'use_uuid_as_userid', False)
 
 
 def to50beta2(context):
@@ -304,21 +270,12 @@ def upgrade_usergroups_controlpanel_settings(context):
     # get the new registry
     registry = getUtility(IRegistry)
 
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(IUserGroupsSettingsSchema,
-                                         prefix='plone')
-    except KeyError:
-        settings = False
-    if settings:
-        settings.many_groups = site_properties.getProperty('many_groups',
-                                                           False)
-        settings.many_users = site_properties.getProperty('many_users',
-                                                          False)
+    settings = registry.forInterface(IUserGroupsSettingsSchema,
+                                     prefix='plone')
+    settings.many_groups = site_properties.getProperty('many_groups',
+                                                       False)
+    settings.many_users = site_properties.getProperty('many_users',
+                                                      False)
 
 
 def migrate_displayPublicationDateInByline(context):
@@ -329,26 +286,17 @@ def migrate_displayPublicationDateInByline(context):
     # get the new registry
     registry = getUtility(IRegistry)
 
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(IUserGroupsSettingsSchema,
-                                         prefix='plone')
-    except KeyError:
-        settings = False
-    if settings:
-        # get the old site properties
-        portal_url = getToolByName(context, 'portal_url')
-        portal = portal_url.getPortalObject()
-        portal_properties = getToolByName(portal, "portal_properties")
-        site_properties = portal_properties.site_properties
+    settings = registry.forInterface(IUserGroupsSettingsSchema,
+                                     prefix='plone')
+    # get the old site properties
+    portal_url = getToolByName(context, 'portal_url')
+    portal = portal_url.getPortalObject()
+    portal_properties = getToolByName(portal, "portal_properties")
+    site_properties = portal_properties.site_properties
 
-        value = site_properties.getProperty('displayPublicationDateInByline',
-                                            False)
-        settings.display_publication_date_in_byline = value
+    value = site_properties.getProperty('displayPublicationDateInByline',
+                                        False)
+    settings.display_publication_date_in_byline = value
 
 
 def to50rc1(context):

--- a/plone/app/upgrade/v50/profiles/to_rc1/registry.xml
+++ b/plone/app/upgrade/v50/profiles/to_rc1/registry.xml
@@ -2,4 +2,6 @@
 <registry>
   <records interface="Products.CMFPlone.interfaces.ISiteSchema"
            prefix="plone" />
+  <records interface="Products.CMFPlone.interfaces.IUserGroupsSettingsSchema"
+           prefix="plone" />
 </registry>

--- a/plone/app/upgrade/v50/profiles/to_rc3/registry.xml
+++ b/plone/app/upgrade/v50/profiles/to_rc3/registry.xml
@@ -12,8 +12,6 @@
            prefix="plone" />
   <records interface="Products.CMFPlone.interfaces.ITypesSchema"
            prefix="plone" />
-  <records interface="Products.CMFPlone.interfaces.IUserGroupsSettingsSchema"
-           prefix="plone" />
   <records interface="plone.app.iterate.interfaces.IIterateSettings" />
   <records prefix="plone.resources/resource-plone-app-discussion-stylesheets"
         interface='Products.CMFPlone.interfaces.IResourceRegistry'

--- a/plone/app/upgrade/v51/betas.py
+++ b/plone/app/upgrade/v51/betas.py
@@ -28,26 +28,17 @@ def addSortOnProperty(context):
     site_properties = portal_properties.site_properties
     # get the new registry
     registry = getUtility(IRegistry)
-    # XXX: Somehow this code is executed for old migration steps as well
-    # ( < Plone 4 ) and breaks because there is no registry. Looking up the
-    # registry interfaces with 'check=False' will not work, because it will
-    # return a settings object and then fail when we try to access the
-    # attributes.
-    try:
-        settings = registry.forInterface(
-            ISearchSchema,
-            prefix='plone',
-        )
-    except KeyError:
-        settings = False
-    if settings:
-        # migrate the old site properties to the new registry
-        if site_properties.hasProperty('sort_on'):
-            settings.sort_on = site_properties.sort_on
-        else:
-            settings.sort_on = 'relevance'
-        logger.log(logging.INFO,
-                   "Added 'sort_on' property to site_properties.")
+    settings = registry.forInterface(
+        ISearchSchema,
+        prefix='plone',
+    )
+    # migrate the old site properties to the new registry
+    if site_properties.hasProperty('sort_on'):
+        settings.sort_on = site_properties.sort_on
+    else:
+        settings.sort_on = 'relevance'
+    logger.log(logging.INFO,
+               "Added 'sort_on' property to site_properties.")
 
 
 def remove_leftover_skin_layers(context):


### PR DESCRIPTION
IUserGroupsSettingsSchema was not getting installed into the registry before the upgrade step which tries to migrate its values.

This was masked because there are a bunch of registry upgrade steps which swallow errors looking up the record proxy. That's bad because then the settings don't get set but that doesn't become evident until later and results in things like plone/Products.CMFPlone#1390. This also looks like copy-paste programming because in some cases the steps go on to try to set the settings even if the record proxy wasn't successfully obtained. So I'm removing the error handling here so that broken upgrades will be more obvious at upgrade time.