### PR TITLE
Avoid triggering user login migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ Bug fixes:
   Fixes https://github.com/plone/Products.CMFPlone/issues/2238
   [pbauer]
 
+- Avoid triggering an unnecessary migration of user logins
+  when the use_email_as_login setting is migrated to portal_registry.
+  [davisagli]
+
 
 2.0.9 (2017-11-26)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ Bug fixes:
   This fixes running specific upgrade steps via the portal_setup UI.
   [davisagli]
 
+- Avoid triggering an unnecessary migration of user logins
+  when the use_email_as_login setting is migrated to portal_registry.
+  [davisagli]
+
 
 2.0.10 (2017-12-13)
 -------------------
@@ -30,10 +34,6 @@ Bug fixes:
 - Unregister import_steps that were moved to post_handlers.
   Fixes https://github.com/plone/Products.CMFPlone/issues/2238
   [pbauer]
-
-- Avoid triggering an unnecessary migration of user logins
-  when the use_email_as_login setting is migrated to portal_registry.
-  [davisagli]
 
 
 2.0.9 (2017-11-26)

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -167,8 +167,18 @@ def upgrade_security_controlpanel_settings(context):
     settings.enable_user_folders = pmembership.getMemberareaCreationFlag()
     settings.allow_anon_views_about = site_properties.getProperty(
         'allowAnonymousViewAbout', False)
+
+    # suppress migrating login names while setting use_email_as_login to existing value
+    from Products.CMFPlone.controlpanel import events
+    migrate_to_email_login = events.migrate_to_email_login
+    migrate_from_email_login = events.migrate_from_email_login
+    events.migrate_to_email_login = lambda x: None
+    events.migrate_to_email_login = lambda x: None
     settings.use_email_as_login = site_properties.getProperty(
         'use_email_as_login', False)
+    events.migrate_to_email_login = migrate_to_email_login
+    events.migrate_from_email_login = migrate_from_email_login
+
     settings.use_uuid_as_userid = site_properties.getProperty(
         'use_uuid_as_userid', False)
 

--- a/plone/app/upgrade/v50/configure.zcml
+++ b/plone/app/upgrade/v50/configure.zcml
@@ -158,7 +158,7 @@
            />
 
        <gs:upgradeStep
-           title="Run to50beta4 upgrade profile"
+           title="Upgrade plone.app.querystring"
            description=""
            handler=".betas.upgrade_querystring"
            />


### PR DESCRIPTION
This is a bit ugly but avoids unnecessary processing while migrating the use_email_as_login setting from portal_properties to portal_registry. It makes a difference for us in a site with over 100k users.