### PR TITLE
Disable CSRF protection when replacing keyring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Bug fixes:
 - Log progress and ignore bad catalog entries while updating catalog metadata.
   [davisagli]
 
+- Disable CSRF protection when replacing keyring.
+  This fixes running specific upgrade steps via the portal_setup UI.
+  [davisagli]
+
 
 2.0.10 (2017-12-13)
 -------------------

--- a/plone/app/upgrade/v50/alphas.py
+++ b/plone/app/upgrade/v50/alphas.py
@@ -18,10 +18,13 @@ from plone.app.vocabularies.types import BAD_TYPES
 from plone.keyring.interfaces import IKeyManager
 from plone.keyring.keymanager import KeyManager
 from plone.keyring.keyring import Keyring
+from plone.protect.interfaces import IDisableCSRFProtection
 from plone.registry.interfaces import IRegistry
 from zope.component import getSiteManager
 from zope.component import getUtility
 from zope.component.hooks import getSite
+from zope.globalrequest import getRequest
+from zope.interface import alsoProvides
 from zope.schema.interfaces import ConstraintNotSatisfied
 
 try:
@@ -205,6 +208,13 @@ def upgrade_keyring(context):
     if sm.queryUtility(IKeyManager) is None:
         obj = KeyManager()
         sm.registerUtility(aq_base(obj), IKeyManager, '')
+
+    # disable CSRF protection which will fail due to
+    # using different secrets than when the authenticator
+    # was generated
+    request = getRequest()
+    if request is not None:
+        alsoProvides(request, IDisableCSRFProtection)
 
 
 def to50alhpa3(context):


### PR DESCRIPTION
We already do this for @@plone-upgrade, but running this upgrade step via the portal_setup UI would fail because the secrets change so the authenticator check fails.