### PR TITLE
Import setupPasswordPolicyPlugin from canonical place in PlonePAS. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Import ``setupPasswordPolicyPlugin`` from canonical place in ``PlonePAS``.
+  [maurits]
+
 - Log progress and ignore bad catalog entries while updating catalog metadata.
   [davisagli]
 

--- a/plone/app/upgrade/v43/final.py
+++ b/plone/app/upgrade/v43/final.py
@@ -44,7 +44,7 @@ def removePersistentKSSMimeTypeImportStep(context):
 
 def addDefaultPlonePasswordPolicy(context):
     portal = getToolByName(context, 'portal_url').getPortalObject()
-    from Products.PlonePAS.Extensions.Install import setupPasswordPolicyPlugin
+    from Products.PlonePAS.setuphandlers import setupPasswordPolicyPlugin
     setupPasswordPolicyPlugin(portal)
 
 
@@ -323,7 +323,7 @@ def removeFakeKupu(context):
 
 def addSortOnProperty(context):
     """Add sort_on field to search controlpanel.
-    
+
     The default value of this field is relevance.
     """
     site_properties = getToolByName(context, 'portal_properties').site_properties

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'Products.CMFEditions',
         'Products.CMFQuickInstallerTool',
         'Products.GenericSetup>=1.8.1',
-        'Products.PlonePAS',
+        'Products.PlonePAS >= 5.0.1',
         'Products.PluggableAuthService',
         'Products.ZCatalog >= 2.13.4',
         'Zope2',


### PR DESCRIPTION
Requires PlonePAS 5.0.1 or higher, which has been there since Plone 4.3.8.