### PR TITLE
Import PlonePAS.setuphandlers instead of Extensions/Install.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Import from ``Products.PlonePAS.setuphandlers`` instead of ``Extensions/Install.py``.
+  [maurits]
 
 
 1.4.3 (2017-09-08)

--- a/plone/app/upgrade/v30/alphas.py
+++ b/plone/app/upgrade/v30/alphas.py
@@ -404,7 +404,7 @@ def updateMemberSecurity(context):
 
 
 def updatePASPlugins(context):
-    from Products.PlonePAS.Extensions.Install import activatePluginInterfaces
+    from Products.PlonePAS.setuphandlers import activatePluginInterfaces
 
     portal = getToolByName(context, 'portal_url').getPortalObject()
 

--- a/plone/app/upgrade/v30/betas.py
+++ b/plone/app/upgrade/v30/betas.py
@@ -94,7 +94,7 @@ def cleanDefaultCharset(context):
 
 
 def addAutoGroupToPAS(context):
-    from Products.PlonePAS.Extensions.Install import activatePluginInterfaces
+    from Products.PlonePAS.setuphandlers import activatePluginInterfaces
 
     portal = getToolByName(context, 'portal_url').getPortalObject()
     sout = StringIO()

--- a/plone/app/upgrade/v43/final.py
+++ b/plone/app/upgrade/v43/final.py
@@ -44,7 +44,7 @@ def removePersistentKSSMimeTypeImportStep(context):
 
 def addDefaultPlonePasswordPolicy(context):
     portal = getToolByName(context, 'portal_url').getPortalObject()
-    from Products.PlonePAS.Extensions.Install import setupPasswordPolicyPlugin
+    from Products.PlonePAS.setuphandlers import setupPasswordPolicyPlugin
     setupPasswordPolicyPlugin(portal)
 
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         'Products.GenericSetup>=1.8.1',
         'Products.MimetypesRegistry',
         # 'Products.PloneLanguageTool',
-        'Products.PlonePAS',
+        'Products.PlonePAS >= 5.0.1',
         'Products.PluggableAuthService',
         'Products.PortalTransforms',
         'Products.ResourceRegistries',


### PR DESCRIPTION
Requires Products.PlonePAS 5.0.1 or higher.