### PR TITLE
Prepare for disappearance of CMFQuickInstaller.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Removed hard dependency on ``CMFQuickInstallerTool``.
+  And marked the v52 module as non installable.  [maurits]
+
 - Import ``setupPasswordPolicyPlugin`` from canonical place in ``PlonePAS``.
   [maurits]
 

--- a/plone/app/upgrade/__init__.py
+++ b/plone/app/upgrade/__init__.py
@@ -1,7 +1,15 @@
 import pkg_resources
 import sys
 from zope.interface import implementer
-from Products.CMFQuickInstallerTool.interfaces import INonInstallable
+try:
+    # This is needed on Plone 5.0.
+    from Products.CMFQuickInstallerTool.interfaces import INonInstallable
+except ImportError:
+    # On Plone 5.1 we can use this.
+    # Note that the interface is available on earlier Plones,
+    # but not for the getNonInstallableProducts method.
+    # So we must use this as fallback.
+    from Products.CMFPlone.interfaces import INonInstallable
 from plone.app.upgrade.utils import alias_module
 import bbb
 import bbbd
@@ -19,6 +27,7 @@ class HiddenProducts(object):
             'plone.app.upgrade.v43',
             'plone.app.upgrade.v50',
             'plone.app.upgrade.v51',
+            'plone.app.upgrade.v52',
         ]
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         'Products.CMFPlone',
         'Products.CMFCore',
         'Products.CMFEditions',
-        'Products.CMFQuickInstallerTool',
         'Products.GenericSetup>=1.8.1',
         'Products.PlonePAS >= 5.0.1',
         'Products.PluggableAuthService',


### PR DESCRIPTION
Removed hard dependency on CMFQuickInstallerTool.
And marked the v52 module as non installable.

This all still works on Plone 5.0 and higher.