### PR TITLE
Hide our 'products' from installation for both QI and CMFPlone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Hide our 'products' from installation for both CMFQuickInstallerTool and CMFPlone.
+  [maurits]
 
 
 2.0.11 (2018-02-05)

--- a/plone/app/upgrade/__init__.py
+++ b/plone/app/upgrade/__init__.py
@@ -1,34 +1,8 @@
 import pkg_resources
 import sys
-from zope.interface import implementer
-try:
-    # This is needed on Plone 5.0.
-    from Products.CMFQuickInstallerTool.interfaces import INonInstallable
-except ImportError:
-    # On Plone 5.1 we can use this.
-    # Note that the interface is available on earlier Plones,
-    # but not for the getNonInstallableProducts method.
-    # So we must use this as fallback.
-    from Products.CMFPlone.interfaces import INonInstallable
 from plone.app.upgrade.utils import alias_module
 import bbb
 import bbbd
-
-
-@implementer(INonInstallable)
-class HiddenProducts(object):
-    """This hides the upgrade profiles from the quick installer tool."""
-
-    def getNonInstallableProducts(self):
-        return [
-            'plone.app.upgrade.v40',
-            'plone.app.upgrade.v41',
-            'plone.app.upgrade.v42',
-            'plone.app.upgrade.v43',
-            'plone.app.upgrade.v50',
-            'plone.app.upgrade.v51',
-            'plone.app.upgrade.v52',
-        ]
 
 try:
     from zope.app.cache.interfaces.ram import IRAMCache
@@ -160,3 +134,21 @@ try:
     PasswordResetTool  # pyflakes
 except ImportError:
     sys.modules['Products.PasswordResetTool.PasswordResetTool'] = bbb
+
+
+class HiddenProducts(object):
+    """This hides the upgrade profiles from the quick installer tool."""
+
+    def getNonInstallableProducts(self):
+        return [
+            'plone.app.upgrade.v40',
+            'plone.app.upgrade.v41',
+            'plone.app.upgrade.v42',
+            'plone.app.upgrade.v43',
+            'plone.app.upgrade.v50',
+            'plone.app.upgrade.v51',
+            'plone.app.upgrade.v52',
+        ]
+
+    def getNonInstallableProfiles(self):
+        return []

--- a/plone/app/upgrade/configure.zcml
+++ b/plone/app/upgrade/configure.zcml
@@ -13,7 +13,15 @@
     <include package=".v52" zcml:condition="have plone-52" />
 
     <utility
+        zcml:condition="have plone-51"
         factory=".HiddenProducts"
+        provides="Products.CMFPlone.interfaces.INonInstallable"
+        name="plone.app.upgrade"
+        />
+    <utility
+        zcml:condition="installed Products.CMFQuickInstallerTool"
+        factory=".HiddenProducts"
+        provides="Products.CMFQuickInstallerTool.interfaces.INonInstallable"
         name="plone.app.upgrade"
         />
 


### PR DESCRIPTION
The plone.app.upgrade.v40 package, etc, would be shown as installable
if you had a branch of CMFPlone with the QI code completely removed (scheduled for Plone 6)
but with the Products.CMFQuickInstallerTool package still available.

Now we register the HiddenProducts factory twice in that case, for both INonInstallable interfaces.