### PR TITLE
Rename retina_scales to highpixeldensity_scales.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New features:
 
 Bug fixes:
 
+- Rename retina_scales to highpixeldensity_scales.
+  Fixes `issue 2331 <https://github.com/plone/Products.CMFPlone/issues/2331>`_.
+  [maurits]
+
 - Hide our 'products' from installation for both CMFQuickInstallerTool and CMFPlone.
   [maurits]
 

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -212,10 +212,10 @@ Add image scaling options to image handling control panel.
         destination="5111"
         profile="Products.CMFPlone:plone">
 
-        <gs:upgradeStep
-            title="Miscellaneous"
-            description=""
-            handler="..utils.null_upgrade_step"
+        <gs:upgradeDepends
+            title="Run to511 upgrade profile."
+            description="Rename retina_scales to highpixeldensity_scales."
+            import_profile="plone.app.upgrade.v51:to511"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v51/profiles.zcml
+++ b/plone/app/upgrade/v51/profiles.zcml
@@ -59,4 +59,13 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:registerProfile
+      name="to511"
+      title="Upgrade profile for Plone 5.1 to Plone 5.1.1"
+      description=""
+      directory="profiles/to_511"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
 </configure>

--- a/plone/app/upgrade/v51/profiles/to_511/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_511/registry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<registry>
+
+  <!-- Rename retina_scales to highpixeldensity_scales. -->
+  <records interface="Products.CMFPlone.interfaces.IImagingSchema"
+           prefix="plone" />
+
+</registry>


### PR DESCRIPTION
Fixes https://github.com/plone/Products.CMFPlone/issues/2331

Actually, this simply reregisters `IImagingSchema` in the configuration registry.
I tried to see if I could take over the value of `retina_scales` if set, but I did not succeed.
Should be fine: the only problem is when you upgraded your Plone Site to 5.1rc3, and set a different value for `retina_scales`, and you run the upgrade from this PR, then you lose your customization. So very minor.