### PR TITLE
Temporarily removed 5113 profile upgrade step.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Temporarily removed 5113 profile upgrade step.
+  You would get a warning when upgrading to Plone 5.1.2.
+  [maurits]
 
 
 2.0.14 (2018-04-09)

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -238,17 +238,4 @@ Add image scaling options to image handling control panel.
 
     </gs:upgradeSteps>
 
-    <gs:upgradeSteps
-        source="5112"
-        destination="5113"
-        profile="Products.CMFPlone:plone">
-
-        <gs:upgradeStep
-            title="Miscellaneous"
-            description=""
-            handler="..utils.null_upgrade_step"
-            />
-
-    </gs:upgradeSteps>
-
 </configure>


### PR DESCRIPTION
You would get a warning when upgrading to Plone 5.1.2. This reverts commit b352b5b22dd99de3b2e97a2e0ae7004615df86ba.

Note: this will give an error on Jenkins 5.1 when merged, because CMFPlone 5.1 branch *does* have profile version 5113. So two options:

1. Merge it, release it, re-add the 5113 upgrade step.
2. Release a new version from this PR branch, probably version 2.0.14.1.