### PR TITLE
Reduce code complexity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New features:
 
 Bug fixes:
 
+- Made several functions less complex by splitting them.  [maurits]
+
 - Improved code quality.  [maurits]
 
 

--- a/plone/app/upgrade/v41/alphas.py
+++ b/plone/app/upgrade/v41/alphas.py
@@ -46,7 +46,12 @@ def add_siteadmin_role(context):
             title='Site Administrators',
             roles=['Site Administrator'],
         )
+    # add_siteadmin_role was too complex, so we split it.
+    _update_rolemap_for_siteadmin_role(portal)
+    _update_workflows_for_siteadmin_role(portal)
 
+
+def _update_rolemap_for_siteadmin_role(portal):
     # update rolemap:
     # add Site Administrator role to permissions that have the Manager role,
     # plus some additional ones that only have Manager as a default role
@@ -97,6 +102,8 @@ def add_siteadmin_role(context):
     for permission_id in extra_permissions:
         portal.manage_permission(permission_id, ['Site Administrator', ], True)
 
+
+def _update_workflows_for_siteadmin_role(portal):
     # update workflows:
     # add Site Administrator role where Manager already is;
     wtool = getToolByName(portal, 'portal_workflow')

--- a/plone/app/upgrade/v43/alphas.py
+++ b/plone/app/upgrade/v43/alphas.py
@@ -39,13 +39,19 @@ def reindex_sortable_title(context):
             else:
                 change.extend(list(keys))
     pghandler.finish()
-    update_metadata = 'sortable_title' in _catalog.schema
+    # flake8 complained that reindex_sortable_title is too complex (11).
+    # So we split it in two.
+    _update_sortable_title(_catalog, change)
+
+
+def _update_sortable_title(catalog, change):
+    update_metadata = 'sortable_title' in catalog.schema
     pghandler = ZLogHandler(1000)
     logger.info('Updating sortable_title index')
     pghandler.init('Updating sortable_title index', len(change))
     for i, rid in enumerate(change):
         pghandler.report(i)
-        brain = _catalog[rid]
+        brain = catalog[rid]
         try:
             obj = brain.getObject()
         except (AttributeError, KeyError):
@@ -134,33 +140,34 @@ def to43alpha1(context):
     upgradePloneAppJQuery(context)
 
 
+def _getDexterityFolderTypes(portal):
+    try:
+        from plone.dexterity.interfaces import IDexterityFTI
+        from plone.dexterity.utils import resolveDottedName
+        from Products.CMFPlone.interfaces.syndication import ISyndicatable
+    except ImportError:
+        return set([])
+
+    portal_types = getToolByName(portal, 'portal_types')
+    types = [fti for fti in portal_types.listTypeInfo() if
+             IDexterityFTI.providedBy(fti)]
+
+    ftypes = set([])
+    for _type in types:
+        klass = resolveDottedName(_type.klass)
+        if ISyndicatable.implementedBy(klass):
+            ftypes.add(_type.getId())
+    return ftypes
+
+
 def upgradeSyndication(context):
     from zope.component import getUtility, getSiteManager
     from plone.registry.interfaces import IRegistry
     from Products.CMFCore.interfaces import ISyndicationTool
-    from Products.CMFPlone.interfaces.syndication import ISyndicatable
     from Products.CMFPlone.interfaces.syndication import (
-        ISiteSyndicationSettings, IFeedSettings)
+        ISiteSyndicationSettings)
 
     portal = getToolByName(context, 'portal_url').getPortalObject()
-
-    def getDexterityFolderTypes():
-        try:
-            from plone.dexterity.interfaces import IDexterityFTI
-            from plone.dexterity.utils import resolveDottedName
-        except ImportError:
-            return set([])
-
-        portal_types = getToolByName(portal, 'portal_types')
-        types = [fti for fti in portal_types.listTypeInfo() if
-                 IDexterityFTI.providedBy(fti)]
-
-        ftypes = set([])
-        for _type in types:
-            klass = resolveDottedName(_type.klass)
-            if ISyndicatable.implementedBy(klass):
-                ftypes.add(_type.getId())
-        return ftypes
 
     logger.info('Migrating syndication tool')
     registry = getUtility(IRegistry)
@@ -169,6 +176,9 @@ def upgradeSyndication(context):
     # available
     try:
         old_synd_tool = portal.portal_syndication
+    except AttributeError:
+        pass
+    else:
         try:
             synd_settings.allowed = old_synd_tool.isAllowed
         except AttributeError:
@@ -178,39 +188,47 @@ def upgradeSyndication(context):
         except AttributeError:
             pass
         portal.manage_delObjects(['portal_syndication'])
-    except AttributeError:
-        pass
+
     sm = getSiteManager()
     sm.unregisterUtility(provided=ISyndicationTool)
+    # flake8 complained that upgradeSyndication is too complex (11).
+    # So we split it in two.
+    _update_syndication_info(portal)
+
+
+def _update_syndication_info(portal):
     # now, go through all containers and look for syndication_info
     # objects
+    from Products.CMFPlone.interfaces.syndication import IFeedSettings
+    from Products.CMFPlone.interfaces.syndication import ISyndicatable
     catalog = getToolByName(portal, 'portal_catalog')
     # get all folder types from portal_types
     at_tool = getToolByName(portal, 'archetype_tool')
     folder_types = set([])
     for _type in at_tool.listPortalTypesWithInterfaces([ISyndicatable]):
         folder_types.add(_type.getId())
-    folder_types = folder_types | getDexterityFolderTypes()
+    folder_types = folder_types | _getDexterityFolderTypes(portal)
     for brain in catalog(portal_type=tuple(folder_types)):
         try:
             obj = brain.getObject()
         except (AttributeError, KeyError):
             continue
-        if 'syndication_information' in obj.objectIds():
-            # just having syndication info object means
-            # syndication is enabled
-            info = obj.syndication_information
-            try:
-                settings = IFeedSettings(obj)
-            except TypeError:
-                continue
-            settings.enabled = True
-            try:
-                settings.max_items = info.max_items
-            except AttributeError:
-                pass
-            settings.feed_types = ('RSS',)
-            obj.manage_delObjects(['syndication_information'])
+        if 'syndication_information' not in obj.objectIds():
+            return
+        # just having syndication info object means
+        # syndication is enabled
+        info = obj.syndication_information
+        try:
+            settings = IFeedSettings(obj)
+        except TypeError:
+            continue
+        settings.enabled = True
+        try:
+            settings.max_items = info.max_items
+        except AttributeError:
+            pass
+        settings.feed_types = ('RSS',)
+        obj.manage_delObjects(['syndication_information'])
 
 
 def to43alpha2(context):

--- a/plone/app/upgrade/v43/final.py
+++ b/plone/app/upgrade/v43/final.py
@@ -291,6 +291,12 @@ def removeFakeKupu(context):
         # Note that this does nothing when the configlet is not there.
         control_panel.unregisterConfiglet('kupu')
         logger.info('Removed kupu control panel configlet.')
+
+    # The function was too complex, so we split it.
+    _remove_kupu_from_props(portal)
+
+
+def _remove_kupu_from_props(portal):
     # Remove editor from site_properties.
     pprops = getToolByName(portal, 'portal_properties', None)
     available_editors = []
@@ -315,7 +321,7 @@ def removeFakeKupu(context):
     # Remove from portal_memberdata.  Note that you can use
     # collective.setdefaulteditor if you want more options, like
     # updating the chosen editor for all existing members.
-    member_data = getToolByName(context, 'portal_memberdata')
+    member_data = getToolByName(portal, 'portal_memberdata')
     if member_data.getProperty('wysiwyg_editor') == 'Kupu':
         member_data._updateProperty('wysiwyg_editor', '')
         logger.info('Changed new member wysiwyg_editor to site default.')


### PR DESCRIPTION
This builds on PR #157. At the end of that PR you still have a few complexity errors:

```
$ bin/code-analysis
Check clean lines....................[ OK ] in 0.132s
Flake8..........................[ FAILURE ] in 1.715s
plone/app/upgrade/utils.py:266:1: C901 'updateIconsInBrains' is too complex (19)
plone/app/upgrade/v41/alphas.py:30:1: C901 'add_siteadmin_role' is too complex (14)
plone/app/upgrade/v40/alphas.py:179:1: C901 'migrateActionIcons' is too complex (17)
plone/app/upgrade/v40/betas.py:43:1: C901 'updateSafeHTMLConfig' is too complex (11)
plone/app/upgrade/v40/betas.py:220:1: C901 'fix_cataloged_interface_names' is too complex (11)
plone/app/upgrade/v43/alphas.py:17:1: C901 'reindex_sortable_title' is too complex (11)
plone/app/upgrade/v43/alphas.py:137:1: C901 'upgradeSyndication' is too complex (21)
plone/app/upgrade/v43/final.py:238:1: C901 'removeFakeKupu' is too complex (15)
plone/app/upgrade/v50/betas.py:495:1: C901 'to50rc3' is too complex (19)
Check MANIFEST.in....................[ OK ] in 2.107s
```

This new PR, with currently one extra commit (1933ad6dab7121c46ef3f8a2fd7053b822b988ca), fixes all those by splitting the functions.