### PR TITLE
Add upgrade steps for Datatables on Plone 5.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add upgrade steps for Datatbles on Plone 5.2
+  [frapell]
 
 Bug fixes:
 

--- a/plone/app/upgrade/v52/profiles/to_alpha1/registry.xml
+++ b/plone/app/upgrade/v52/profiles/to_alpha1/registry.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0"?>
+<registry>
+
+  <records prefix="plone.resources/mockup-patterns-datatables"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++resource++mockup/datatables/pattern.js</value>
+      <value key="css">
+        <element>++resource++mockup/datatables/pattern.datatables.less</element>
+      </value>
+  </records>
+
+  <!-- DataTables resources -->
+  <records prefix="plone.resources/datatables.net"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net/js/jquery.dataTables.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-bs"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-bs/js/dataTables.bootstrap.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-autofill"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-autofill/js/dataTables.autoFill.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-autofill-bs"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-autofill-bs/js/autoFill.bootstrap.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-buttons"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-buttons/js/dataTables.buttons.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-buttons-colvis"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-buttons/js/buttons.colVis.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-buttons-flash"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-buttons/js/buttons.flash.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-buttons-html5"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-buttons/js/buttons.html5.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-buttons-print"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-buttons/js/buttons.print.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-buttons-bs"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-buttons-bs/js/buttons.bootstrap.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-colreorder"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-colreorder/js/dataTables.colReorder.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-fixedcolumns"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-fixedcolumns/js/dataTables.fixedColumns.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-fixedheader"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-fixedheader/js/dataTables.fixedHeader.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-keytable"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-keytable/js/dataTables.keyTable.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-responsive"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-responsive/js/dataTables.responsive.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-responsive-bs"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-responsive-bs/js/responsive.bootstrap.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-rowreorder"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-rowreorder/js/dataTables.rowReorder.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-scroller"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-scroller/js/dataTables.scroller.min.js</value>
+  </records>
+
+  <records prefix="plone.resources/datatables.net-select"
+            interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+      <value key="js">++plone++static/components/datatables.net-select/js/dataTables.select.min.js</value>
+  </records>
+
+  <!-- Update ``last_compilation`` to deliver new bundles -->
+  <records
+      prefix="plone.bundles/plone"
+      interface="Products.CMFPlone.interfaces.IBundleRegistry"
+      purge="False">
+    <value key="last_compilation">2018-07-10 00:00:00</value>
+  </records>
+  <records
+      prefix="plone.bundles/plone-logged-in"
+      interface="Products.CMFPlone.interfaces.IBundleRegistry"
+      purge="False">
+    <value key="last_compilation">2018-07-10 00:00:00</value>
+  </records>
+
+</registry>


### PR DESCRIPTION
This is the upgrade steps for https://github.com/plone/Products.CMFPlone/pull/2472

However, if 5.1.4 is released before 5.2 with https://github.com/plone/plone.app.upgrade/pull/168, then I don't think this needs to be merged...