### PR TITLE
Remove jquery-highlightsearchterms and plone_ecmascript layer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New features:
 - Add upgrade steps for Datatbles on Plone 5.1.4
   [frapell]
 
+- Add upgrade step removing the jquery-highlightsearchterms resource
+  and the plone_ecmascript skin layer, on Plone 5.2
+
 Bug fixes:
 
 - *add item here*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
   [frapell]
 
 - Add upgrade step removing the jquery-highlightsearchterms resource
-  and the plone_ecmascript skin layer, on Plone 5.2
+  and the plone_ecmascript skin layer, on Plone 5.2 and 5.1.4
 
 Bug fixes:
 

--- a/plone/app/upgrade/v51/configure.zcml
+++ b/plone/app/upgrade/v51/configure.zcml
@@ -265,7 +265,7 @@ Add image scaling options to image handling control panel.
         <gs:upgradeStep
             title="Miscellaneous"
             description=""
-            handler="..utils.null_upgrade_step"
+            handler=".final.remove_highlightsearchterms"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v51/final.py
+++ b/plone/app/upgrade/v51/final.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
+from plone.app.upgrade.utils import cleanUpSkinsTool
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from zExceptions import BadRequest
+from zope.component import getUtility
 
 import logging
 
@@ -38,3 +41,14 @@ def fix_i18n_domain(context):
                 'Action object/%s does not have an i18n_domain property',
                 action_id,
             )
+
+
+def remove_highlightsearchterms(context):
+    portal = getToolByName(context, 'portal_url').getPortalObject()
+    cleanUpSkinsTool(portal)
+
+    registry = getUtility(IRegistry)
+    record = 'plone.bundles/plone-legacy.resources'
+    resources = registry.records[record]
+    if u'jquery-highlightsearchterms' in resources.value:
+        resources.value.remove(u'jquery-highlightsearchterms')

--- a/plone/app/upgrade/v51/profiles/to_514/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_514/registry.xml
@@ -105,18 +105,23 @@
       <value key="js">++plone++static/components/datatables.net-select/js/dataTables.select.min.js</value>
   </records>
 
+  <records prefix="plone.resources/jquery-highlightsearchterms"
+           interface='Products.CMFPlone.interfaces.IResourceRegistry'
+           remove="True">
+  </records>
+
   <!-- Update ``last_compilation`` to deliver new bundles -->
   <records
       prefix="plone.bundles/plone"
       interface="Products.CMFPlone.interfaces.IBundleRegistry"
       purge="False">
-    <value key="last_compilation">2018-07-10 00:00:00</value>
+    <value key="last_compilation">2018-09-06 00:00:00</value>
   </records>
   <records
       prefix="plone.bundles/plone-logged-in"
       interface="Products.CMFPlone.interfaces.IBundleRegistry"
       purge="False">
-    <value key="last_compilation">2018-07-10 00:00:00</value>
+    <value key="last_compilation">2018-09-06 00:00:00</value>
   </records>
 
 </registry>

--- a/plone/app/upgrade/v51/profiles/to_514/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_514/registry.xml
@@ -124,4 +124,10 @@
     <value key="last_compilation">2018-09-06 00:00:00</value>
   </records>
 
+  <!-- Update legacy bundle -->
+  <records prefix="plone.bundles/plone-legacy"
+            interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+    <value key="last_compilation"></value>
+  </records>
+
 </registry>

--- a/plone/app/upgrade/v51/profiles/to_514/skins.xml
+++ b/plone/app/upgrade/v51/profiles/to_514/skins.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="portal_skins">
+  <object
+      name="plone_ecmascript"
+      meta_type="Filesystem Directory View"
+      directory="Products.CMFPlone:skins/plone_ecmascript"
+      remove="True"/>
+  <skin-path name="*">
+    <layer name="plone_ecmascript" remove="True"/>
+  </skin-path>
+</object>

--- a/plone/app/upgrade/v52/alphas.py
+++ b/plone/app/upgrade/v52/alphas.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from plone.app.upgrade.utils import cleanUpSkinsTool
 from plone.app.upgrade.utils import loadMigrationProfile
+from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
+from zope.component import getUtility
 
 import logging
 
@@ -13,3 +15,9 @@ def to52alpha1(context):
     loadMigrationProfile(context, 'profile-plone.app.upgrade.v52:to52alpha1')
     portal = getToolByName(context, 'portal_url').getPortalObject()
     cleanUpSkinsTool(portal)
+
+    registry = getUtility(IRegistry)
+    record = 'plone.bundles/plone-legacy.resources'
+    resources = registry.records[record]
+    if u'jquery-highlightsearchterms' in resources.value:
+        resources.value.remove(u'jquery-highlightsearchterms')

--- a/plone/app/upgrade/v52/profiles/to_alpha1/registry.xml
+++ b/plone/app/upgrade/v52/profiles/to_alpha1/registry.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<registry>
+
+
+  <records prefix="plone.resources/jquery-highlightsearchterms"
+           interface='Products.CMFPlone.interfaces.IResourceRegistry'
+           remove="True">
+  </records>
+
+  <!-- Update ``last_compilation`` to deliver new bundles -->
+  <records
+      prefix="plone.bundles/plone"
+      interface="Products.CMFPlone.interfaces.IBundleRegistry"
+      purge="False">
+    <value key="last_compilation">2018-09-06 00:00:00</value>
+  </records>
+  <records
+      prefix="plone.bundles/plone-logged-in"
+      interface="Products.CMFPlone.interfaces.IBundleRegistry"
+      purge="False">
+    <value key="last_compilation">2018-09-06 00:00:00</value>
+  </records>
+
+</registry>

--- a/plone/app/upgrade/v52/profiles/to_alpha1/registry.xml
+++ b/plone/app/upgrade/v52/profiles/to_alpha1/registry.xml
@@ -7,18 +7,10 @@
            remove="True">
   </records>
 
-  <!-- Update ``last_compilation`` to deliver new bundles -->
-  <records
-      prefix="plone.bundles/plone"
-      interface="Products.CMFPlone.interfaces.IBundleRegistry"
-      purge="False">
-    <value key="last_compilation">2018-09-06 00:00:00</value>
-  </records>
-  <records
-      prefix="plone.bundles/plone-logged-in"
-      interface="Products.CMFPlone.interfaces.IBundleRegistry"
-      purge="False">
-    <value key="last_compilation">2018-09-06 00:00:00</value>
+  <!-- Update legacy bundle -->
+  <records prefix="plone.bundles/plone-legacy"
+            interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+    <value key="last_compilation"></value>
   </records>
 
 </registry>

--- a/plone/app/upgrade/v52/profiles/to_alpha1/skins.xml
+++ b/plone/app/upgrade/v52/profiles/to_alpha1/skins.xml
@@ -8,4 +8,12 @@
   <skin-path name="*">
     <layer name="plone_login" remove="True"/>
   </skin-path>
+  <object
+      name="plone_ecmascript"
+      meta_type="Filesystem Directory View"
+      directory="Products.CMFPlone:skins/plone_ecmascript"
+      remove="True"/>
+  <skin-path name="*">
+    <layer name="plone_ecmascript" remove="True"/>
+  </skin-path>
 </object>


### PR DESCRIPTION
Remove the jquery-highlightsearchterms resource, and the - now empty - plone_ecmascript skin layer. See https://github.com/plone/Products.CMFPlone/pull/1963/commits and https://github.com/plone/Products.CMFPlone/issues/1811 https://github.com/plone/Products.CMFPlone/issues/1801