### PR TITLE
[Do not merge] Require plone.app.imaging because an upgrade profile depends on it

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Require plone.app.imaging because an upgrade profile depends on it
+  [ale-rt]
 
 - Update resources for plone.app.event.  [agitator]
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'setuptools',
         'plone.portlets',
         'plone.app.folder',
+        'plone.app.imaging',
         'transaction',
         'zope.component',
         'zope.interface',


### PR DESCRIPTION
I think that (maybe because of this zopefoundation/Products.GenericSetup#64) we need to require `plone.app.imaging` in order to depend on it in this upgrade profile: https://github.com/plone/plone.app.upgrade/blob/425e049511a939db61d3262e60e5526e845c0018/plone/app/upgrade/v40/profiles/to_alpha1/metadata.xml
