### PR TITLE
make plone.app.folder a conditional dependency

### DIFF
--- a/news/175.bugfix
+++ b/news/175.bugfix
@@ -1,0 +1,3 @@
+make `plone.app.folder` import conditional, because the package is gone in Plone >= 5.2
+
+[petschki]

--- a/plone/app/upgrade/v40/alphas.py
+++ b/plone/app/upgrade/v40/alphas.py
@@ -477,7 +477,10 @@ def migrateMailHost(context):
 
 
 def migrateFolders(context):
-    from plone.app.folder.migration import BTreeMigrationView
+    try:
+        from plone.app.folder.migration import BTreeMigrationView
+    except ImportError:
+        return
 
     class MigrationView(BTreeMigrationView):
 

--- a/plone/app/upgrade/v40/tests.py
+++ b/plone/app/upgrade/v40/tests.py
@@ -327,9 +327,13 @@ class TestMigrations_v4_0alpha1(MigrationTest):
         self.assertEqual(new_mh.force_tls, False)
 
     def testFolderMigration(self):
-        from plone.app.folder.tests.content import create
-        from plone.app.folder.tests.test_migration import reverseMigrate
-        from plone.app.folder.tests.test_migration import isSaneBTreeFolder
+        try:
+            from plone.app.folder.tests.content import create
+            from plone.app.folder.tests.test_migration import reverseMigrate
+            from plone.app.folder.tests.test_migration import isSaneBTreeFolder
+        except ImportError:
+            return
+
         # create a folder in an unmigrated state & check it's broken...
         folder = create('Folder', self.portal, 'foo', title='Foo')
         reverseMigrate(self.portal)
@@ -458,7 +462,10 @@ class TestMigrations_v4_0alpha5(MigrationTest):
         self.assertEqual(classictheme.resources_css, [])
 
     def testGetObjPositionInParentIndex(self):
-        from plone.app.folder.nogopip import GopipIndex
+        try:
+            from plone.app.folder.nogopip import GopipIndex
+        except ImportError:
+            return
         catalog = self.portal.portal_catalog
         catalog.delIndex('getObjPositionInParent')
         catalog.addIndex('getObjPositionInParent', 'FieldIndex')

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     install_requires=[
         'setuptools',
         'plone.portlets',
-        'plone.app.folder',
         'transaction',
         'zope.component',
         'zope.interface',


### PR DESCRIPTION
because in Plone 5.2 `plone.app.folder` will be removed we have to make imports for old migration steps conditional here