### PR TITLE
Fix upgrading 5.0.x to 5.2 

### DIFF
--- a/news/193.bugfix
+++ b/news/193.bugfix
@@ -1,0 +1,1 @@
+Add alias for GopipIndex to fix migrations to 5.2

--- a/plone/app/upgrade/__init__.py
+++ b/plone/app/upgrade/__init__.py
@@ -144,6 +144,14 @@ except ImportError:
     sys.modules['Products.PasswordResetTool.PasswordResetTool'] = bbb
 
 
+try:
+    from plone.app.folder.nogopip import GopipIndex
+    GopipIndex  # pyflakes
+except ImportError:
+    from plone.folder.nogopip import GopipIndex
+    alias_module('plone.app.folder.nogopip.GopipIndex', GopipIndex)
+
+
 class HiddenProducts(object):
     """This hides the upgrade profiles from the quick installer tool."""
 


### PR DESCRIPTION
It broke during a query for vocabulary population after GopipIndex was moved to plone.folder 
Fixes https://github.com/plone/Products.CMFPlone/issues/2728