### PR TITLE
Rebuild the plone.app.redirector information.

### DIFF
--- a/news/2799.feature
+++ b/news/2799.feature
@@ -1,0 +1,2 @@
+Added upgrade step to initialize the date and manual information for redirects.
+[maurits]

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -56,9 +56,9 @@
         profile="Products.CMFPlone:plone">
 
         <gs:upgradeStep
-            title="Miscellaneous"
-            description=""
-            handler="..utils.null_upgrade_step"
+            title="Rebuild the plone.app.redirector information."
+            description="This initializes the date and manual information."
+            handler=".final.rebuild_redirections"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from zope.component import getUtility
+
+import logging
+
+
+logger = logging.getLogger('plone.app.upgrade')
+
+
+def rebuild_redirections(context):
+    """Rebuild the plone.app.redirector information.
+
+    This initializes the date and manual information.
+    """
+    from plone.app.redirector.interfaces import IRedirectionStorage
+
+    storage = getUtility(IRedirectionStorage)
+    if not hasattr(storage, '_rebuild'):
+        logger.warning(
+            'Not rebuilding redirections: '
+            'IRedirectionStorage misses the _rebuild method. '
+        )
+        return
+    logger.info(
+        'Starting rebuild of redirections to '
+        'add date and manual information.'
+    )
+    storage._rebuild()
+    logger.info('Done rebuilding redirections.')


### PR DESCRIPTION
This is the upgrade storage part of https://github.com/plone/Products.CMFPlone/issues/2799.
It calls the new [rebuild method](https://github.com/plone/plone.app.redirector/blob/maurits-extend-paths/plone/app/redirector/storage.py#L115) of `plone.app.redirector`, from https://github.com/plone/plone.app.redirector/pull/19.

I have added a test, which actually functions as a good summary of what the changes in `plone.app.redirector` are and how they affect current data.