### PR TITLE
Reload ISecuritySchema for plone.autologin_after_password_reset

### DIFF
--- a/news/2440.bugfix
+++ b/news/2440.bugfix
@@ -1,0 +1,2 @@
+Reload ISecuritySchema to create plone.autologin_after_password_reset key for Plone 5.2.
+[jensens, agitator, maurits]

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -87,10 +87,9 @@
         destination="5205"
         profile="Products.CMFPlone:plone">
 
-        <gs:upgradeStep
+        <gs:upgradeDepends
             title="Miscellaneous"
-            description=""
-            handler="..utils.null_upgrade_step"
+            import_profile="plone.app.upgrade.v52:to52rc4"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v52/profiles.zcml
+++ b/plone/app/upgrade/v52/profiles.zcml
@@ -29,4 +29,14 @@
       for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
+
+  <genericsetup:registerProfile
+      name="to52rc4"
+      title="Upgrade profile for Plone 5.2rc3 to Plone 5.2rc4"
+      description=""
+      directory="profiles/to_rc4"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
 </configure>

--- a/plone/app/upgrade/v52/profiles/to_rc4/registry/security.xml
+++ b/plone/app/upgrade/v52/profiles/to_rc4/registry/security.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<registry>
+
+  <records interface="Products.CMFPlone.interfaces.ISecuritySchema"
+	           prefix="plone" />
+
+</registry>


### PR DESCRIPTION
This replaces the outdated PR #164. It was created last year, but the relevant code was merged only a week ago, so this PR needed an update.

Without this, you get an error when viewing the Plone Site:

```
KeyError: 'Interface `Products.CMFPlone.interfaces.controlpanel.ISecuritySchema`
defines a field `autologin_after_password_reset`, for which there is no record.'
```
