### PR TITLE
add empty upgrade-steo to run core-addon upgrades when upgrading

### DIFF
--- a/news/211.bugfix
+++ b/news/211.bugfix
@@ -1,0 +1,2 @@
+Add empty upgrade-step to run core-addon upgrades when upgrading.
+[pbauer]

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -99,4 +99,17 @@
 
     </gs:upgradeSteps>
 
+    <gs:upgradeSteps
+        source="5205"
+        destination="5206"
+        profile="Products.CMFPlone:plone">
+
+        <gs:upgradeStep
+            title="Nothing yet except core-addons"
+            description=""
+            handler="..utils.null_upgrade_step"
+            />
+
+    </gs:upgradeSteps>
+
 </configure>


### PR DESCRIPTION
together with https://github.com/plone/Products.CMFPlone/pull/2902

Used for https://github.com/plone/plone.app.discussion/pull/158