### PR TITLE
fix problem in remove_interface_indexes_from_relations_catalog 

### DIFF
--- a/news/225.bugfix
+++ b/news/225.bugfix
@@ -1,0 +1,4 @@
+Fix problem in step to 5.2 beta 1 `remove_interface_indexes_from_relations_catalog`.
+While upgrading the relation-catalog in some real world databases some of the iterated tokens are orphaned.
+Remove them to have a clean relation-catalog afterwards and log a warning.
+[jensens]

--- a/plone/app/upgrade/v52/betas.py
+++ b/plone/app/upgrade/v52/betas.py
@@ -8,7 +8,7 @@ from zope import component
 from zope.interface import Interface
 from zope.intid.interfaces import IIntIds
 from zope.intid.interfaces import IntIdMissingError
-
+from zope.intid.interfaces import ObjectMissingError
 import logging
 import sys
 
@@ -68,7 +68,13 @@ def remove_interface_indexes_from_relations_catalog():
     tokens = [token for token in catalog._relTokens]
     empty = 0
     for token in tokens:
-        relation = catalog.resolveRelationToken(token)
+        try:
+            relation = catalog.resolveRelationToken(token)
+        except ObjectMissingError:
+            logger.warning('Removed token with missing object.')
+            catalog._relTokens.remove(token)
+            continue
+
         if relation.from_object is not None or relation.to_object is not None:
             continue
         catalog.unindex_doc(token)


### PR DESCRIPTION
While iterating when the token is orphaned for some reason, the upgrade fails.
My customers database had this inconsistency, so better we deal with it.