### PR TITLE
Add upgrade step for 5.2.2 to migrate markdown transform settings.

### DIFF
--- a/news/228.feature
+++ b/news/228.feature
@@ -1,0 +1,2 @@
+Add upgrade step to migrate markdown tranform settings to markup control panel.
+[thomasmassmann]

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -149,6 +149,11 @@
             handler=".final.to522"
             />
 
+        <gs:upgradeStep
+            title="Move markdown settings from portal_transforms to Plone registry"
+            handler=".final.move_markdown_transform_settings_to_registry"
+            />
+
     </gs:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
This fixes #228 .

Depends on:
https://github.com/plone/Products.CMFPlone/pull/3077