### PR TITLE
Fix move dotted to named behaviors

### DIFF
--- a/news/235.bugfix
+++ b/news/235.bugfix
@@ -1,0 +1,2 @@
+Fix UnicodeDecodeError in move_dotted_to_named_behaviors when migrating behaviors for content_types where the fti has a special character.
+[pbauer]

--- a/plone/app/upgrade/v52/alphas.py
+++ b/plone/app/upgrade/v52/alphas.py
@@ -49,8 +49,10 @@ def rebuild_memberdata(context):
     for member in ms_tool.searchForMembers():
         try:
             md = MemberData(member, md_tool)
+            logger.info(u'Updated memberdata for {}'.format(member))
         # If we can't create a MemberData record for this member, skip it
-        except:
+        except Exception as e:
+            logger.info(u'Skip broken memberdata for {}: {}'.format(member, e))
             continue
         md_tool.registerMemberData(md._md, md.getId())
 

--- a/plone/app/upgrade/v52/betas.py
+++ b/plone/app/upgrade/v52/betas.py
@@ -54,6 +54,7 @@ def remove_legacy_resource_registries(context):
 
 def remove_interface_indexes_from_relations_catalog():
     """ remove unused interface indexes from relations catalog """
+    logger.info('Removing unused interface indexes from relations catalog.')
     catalog = component.queryUtility(ICatalog)
     indexes_to_remove = [
         'from_interfaces_flattened',

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -74,8 +74,8 @@ def move_dotted_to_named_behaviors(context):
                 )
         fti.behaviors = tuple(behaviors)
         logger.info(
-            'Converted dotted behaviors of {ct} to named behaviors.'.format(
-                ct=fti.title,
+            u'Converted dotted behaviors of {ct} to named behaviors.'.format(
+                ct=safe_unicode(fti.title),
             ),
         )
 


### PR DESCRIPTION
Fix UnicodeDecodeError in move_dotted_to_named_behaviors when migrating behaviors for content_types where the fti has a special character.

```
2020-06-30 14:44:54,150 ERROR   [Zope.SiteErrorLog:18][waitress-3] 1593521094.060.584433488928 http://localhost:8080/Plone/@@plone-upgrade
Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 162, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 359, in publish_module
  Module ZPublisher.WSGIPublisher, line 262, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module Products.PDBDebugMode.wsgi_runcall, line 60, in pdb_runcall
  Module Products.CMFPlone.browser.admin, line 310, in __call__
  Module Products.PDBDebugMode.cmfplone, line 11, in upgrade
  Module <string>, line 3, in upgrade
  Module AccessControl.requestmethod, line 88, in _curried
  Module Products.CMFPlone.MigrationTool, line 358, in upgrade
  Module StringIO, line 271, in getvalue
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 39: ordinal not in range(128)
```

