### PR TITLE
Catch deprecation warnings for LockItem and ILanguageSchema

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,4 @@
+Catch deprecation warnings for ``webdav.LockItem.LockItem`` and ``CMFPlone.interfaces.ILanguageSchema``.
+The first has been moved to ``OFS.LockItem``, the second to ``plone.i18n.interfaces``.
+In older upgrade code, we should still try the old import first.
+[maurits]

--- a/plone/app/upgrade/__init__.py
+++ b/plone/app/upgrade/__init__.py
@@ -5,6 +5,7 @@ from . import bbb
 from . import bbbd
 import pkg_resources
 import sys
+import warnings
 
 
 try:
@@ -163,9 +164,16 @@ if not IS_PRODUCT_RESOURCE_REGISTRIES_INSTALLED:
     sys.modules['Products.ResourceRegistries.tools.CSSRegistry'] = bbb
     sys.modules['Products.ResourceRegistries.tools.JSRegistry'] = bbb
 
+
 try:
-    from webdav.LockItem import LockItem
-    LockItem  # pyflakes
+    with warnings.catch_warnings():
+        # Catch DeprecationWarning:
+        # "LockItem is deprecated. Please import from OFS.LockItem."
+        # Depending on which Plone/Zope version we have, webdav may be gone or re-added.
+        # Anyway, if the import fails, we want to create an alias module.
+        warnings.simplefilter("ignore")
+        from webdav.LockItem import LockItem
+        LockItem  # pyflakes
 except ImportError:
     from OFS.LockItem import LockItem
     alias_module('webdav.LockItem.LockItem', LockItem)

--- a/plone/app/upgrade/v50/betas.py
+++ b/plone/app/upgrade/v50/betas.py
@@ -5,7 +5,6 @@ from plone.app.upgrade.utils import loadMigrationProfile
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import ISiteRoot
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.interfaces import ILanguageSchema
 from Products.CMFPlone.interfaces import IMailSchema
 from Products.CMFPlone.interfaces import IMarkupSchema
 from Products.CMFPlone.interfaces import INavigationSchema
@@ -21,6 +20,18 @@ from zope.schema._bootstrapinterfaces import WrongType
 
 import logging
 import pkg_resources
+import warnings
+
+
+try:
+    with warnings.catch_warnings():
+        # Catch DeprecationWarning:
+        # "ILanguageSchema is deprecated. It has been moved to plone.i18n.interfaces, import from there instead."
+        warnings.simplefilter("ignore")
+        from Products.CMFPlone.interfaces import ILanguageSchema
+except ImportError:
+    # Plone 5.2+
+    from plone.i18n.interfaces import ILanguageSchema
 
 
 logger = logging.getLogger('plone.app.upgrade')


### PR DESCRIPTION
The first has been moved to `OFS.LockItem`, the second to `plone.i18n.interfaces`.
In older upgrade code, we should still try the old import first.
I think you should be able to upgrade to Plone 5.0.10 using a more recent `plone.app.upgrade`.