### PR TITLE
Fixed deprecation warning for zope.site.hooks.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,4 +1,5 @@
 Catch deprecation warnings for ``webdav.LockItem.LockItem`` and ``CMFPlone.interfaces.ILanguageSchema``.
 The first has been moved to ``OFS.LockItem``, the second to ``plone.i18n.interfaces``.
 In older upgrade code, we should still try the old import first.
+Fixed deprecation warning for zope.site.hooks.
 [maurits]

--- a/plone/app/upgrade/tests/base.py
+++ b/plone/app/upgrade/tests/base.py
@@ -11,7 +11,7 @@ from Products.CMFCore.interfaces import IActionCategory
 from Products.CMFCore.interfaces import IActionInfo
 from Products.CMFCore.utils import getToolByName
 from Products.GenericSetup.context import TarballImportContext
-from zope.site.hooks import setSite
+from zope.component.hooks import setSite
 
 import transaction
 import warnings


### PR DESCRIPTION
Only in tests.