### PR TITLE
Plone 5.1.7: Update resource registry last_compilation date.

### DIFF
--- a/news/1006.bugfix
+++ b/news/1006.bugfix
@@ -1,0 +1,2 @@
+Plone 5.1.7: Update resource registry ``last_compilation`` date.
+[maurits]

--- a/plone/app/upgrade/v51/profiles/to_517/registry.xml
+++ b/plone/app/upgrade/v51/profiles/to_517/registry.xml
@@ -20,19 +20,19 @@
       prefix="plone.bundles/plone"
       interface="Products.CMFPlone.interfaces.IBundleRegistry"
       purge="False">
-    <value key="last_compilation">2020-08-03 13:00:00</value>
+    <value key="last_compilation">2020-09-08 09:00:00</value>
   </records>
   <records
       prefix="plone.bundles/plone-logged-in"
       interface="Products.CMFPlone.interfaces.IBundleRegistry"
       purge="False">
-    <value key="last_compilation">2020-08-03 13:00:00</value>
+    <value key="last_compilation">2020-09-08 09:00:00</value>
   </records>
   <records
       prefix="plone.bundles/resourceregistry"
       interface='Products.CMFPlone.interfaces.IBundleRegistry'
       purge="False">
-    <value key="last_compilation">2020-08-03 13:00:00</value>
+    <value key="last_compilation">2020-09-08 09:00:00</value>
   </records>
 
 </registry>


### PR DESCRIPTION
This is the upgrade step for https://github.com/plone/Products.CMFPlone/pull/3169.
Test together with that one.