### PR TITLE
Migrate the plone.site_logo field from ASCII (native string) to Bytes.

### DIFF
--- a/news/3172.bugfix
+++ b/news/3172.bugfix
@@ -1,0 +1,4 @@
+Migrate the ``plone.site_logo`` field from ASCII (native string) to Bytes.
+Otherwise saving the site-controlpanel can fail with a WrongType error
+Fixes `issue 3172 <https://github.com/plone/Products.CMFPlone/issues/3172>`_.
+[maurits]

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -162,9 +162,9 @@
         profile="Products.CMFPlone:plone">
 
         <gs:upgradeStep
-            title="Miscellaneous"
+            title="Migrate site logo from native string to bytes"
             description=""
-            handler="..utils.null_upgrade_step"
+            handler=".final.migrate_site_logo_from_ascii_to_bytes"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -163,10 +163,13 @@ def migrate_site_logo_from_ascii_to_bytes(context):
     you get a WrongType error when saving the site-controlpanel.
     """
     from plone.registry import field
-    from plone.registry import Record
 
     registry = getUtility(IRegistry)
-    record = registry.records['plone.site_logo']
+    record = registry.records.get('plone.site_logo', None)
+    if record is None:
+        # Unexpected.  Registering the interface fixes this.
+        registry.registerInterface(ISiteSchema, prefix="plone")
+        return
     if not isinstance(record.field, field.ASCII):
         # All is well.
         # Actually, we might as well register the interface again for good measure.

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -165,6 +165,8 @@ def migrate_record_from_ascii_to_bytes(field_name, iface, prefix=None):
 
     from Products.CMFPlone.interfaces import ISiteSchema
     migrate_record_from_ascii_to_bytes("plone.site_logo", ISiteSchema, prefix="plone")
+    or:
+    migrate_record_from_ascii_to_bytes("site_logo", ISiteSchema, prefix="plone")
 
     The interface is reregistered to get the new field definition.
     Note: this only works well if you have only *one* field that needs fixing.
@@ -173,10 +175,17 @@ def migrate_record_from_ascii_to_bytes(field_name, iface, prefix=None):
     On Python 2 the full name is less needed, but on Python 3 it is.
     If you are not using a prefix when registering your interface,
     then automatically the identifier of your interface is used as prefix.
-    In that case, use:
+    In that case, you can use both of these:
 
+    migrate_record_from_ascii_to_bytes("field_name", IMy)
     migrate_record_from_ascii_to_bytes(IMy.__identifier__ + ".field_name", IMy)
     """
+    if prefix is None:
+        prefix = iface.__identifier__
+    if not prefix.endswith("."):
+        prefix += '.'
+    if not field_name.startswith(prefix):
+        field_name = prefix + field_name
     registry = getUtility(IRegistry)
     record = registry.records.get(field_name, None)
     if record is None:
@@ -225,6 +234,4 @@ def migrate_site_logo_from_ascii_to_bytes(context):
     With Python 2 this is the same as Bytes, but with Python 3 not:
     you get a WrongType error when saving the site-controlpanel.
     """
-    # Note: on Python 2 passing "site_logo" as field name is enough,
-    # but on Python 3 the full "plone.site_logo" is needed.
     migrate_record_from_ascii_to_bytes("plone.site_logo", ISiteSchema, prefix="plone")

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -168,6 +168,14 @@ def migrate_record_from_ascii_to_bytes(field_name, iface, prefix=None):
 
     The interface is reregistered to get the new field definition.
     Note: this only works well if you have only *one* field that needs fixing.
+
+    For the field name, using the full name including prefix is recommended.
+    On Python 2 the full name is less needed, but on Python 3 it is.
+    If you are not using a prefix when registering your interface,
+    then automatically the identifier of your interface is used as prefix.
+    In that case, use:
+
+    migrate_record_from_ascii_to_bytes(IMy.__identifier__ + ".field_name", IMy)
     """
     registry = getUtility(IRegistry)
     record = registry.records.get(field_name, None)
@@ -217,4 +225,6 @@ def migrate_site_logo_from_ascii_to_bytes(context):
     With Python 2 this is the same as Bytes, but with Python 3 not:
     you get a WrongType error when saving the site-controlpanel.
     """
-    migrate_record_from_ascii_to_bytes("plone.site_logo", ISiteSchema, "plone")
+    # Note: on Python 2 passing "site_logo" as field name is enough,
+    # but on Python 3 the full "plone.site_logo" is needed.
+    migrate_record_from_ascii_to_bytes("plone.site_logo", ISiteSchema, prefix="plone")

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -190,13 +190,14 @@ def migrate_site_logo_from_ascii_to_bytes(context):
         return
     new_record = registry.records['plone.site_logo']
     if isinstance(original_value, six.text_type):
-        # fromUnicode could be called from Text in Python 3.
+        # This is what we expect in Python 3.
+        # fromUnicode could be called fromText in Python 3.
         new_value = new_record.field.fromUnicode(original_value)
     elif isinstance(original_value, bytes):
-        # Unlikely, but let's be careful.
+        # This is what we expect in Python 2.
         new_value = original_value
     else:
-        # Anything else is broken.
+        # Seems impossible, but I like to be careful.
         return
     # Save the new value.
     new_record.value = new_value

--- a/plone/app/upgrade/v52/tests.py
+++ b/plone/app/upgrade/v52/tests.py
@@ -201,11 +201,12 @@ class SiteLogoTest(unittest.TestCase):
         class ITest(Interface):
             testfield = schema.Bytes()
 
-        # These variations all seem to work:
-        migrate_record_from_ascii_to_bytes("testfield", ITest)
-        # migrate_record_from_ascii_to_bytes(record_name, ITest)
-        # migrate_record_from_ascii_to_bytes(record_name, ITest, prefix=ITest.__identifier__)
+        # These variations all seem to work on Python 2, but the first two fail on Python 3,
+        # leading to a record.value of None.
+        # migrate_record_from_ascii_to_bytes("testfield", ITest)
         # migrate_record_from_ascii_to_bytes("testfield", ITest, prefix=ITest.__identifier__)
+        migrate_record_from_ascii_to_bytes(record_name, ITest)
+        # migrate_record_from_ascii_to_bytes(record_name, ITest, prefix=ITest.__identifier__)
         record = self.registry.records[record_name]
         self.assertIsInstance(record.field, field.Bytes)
         self.assertEqual(record.value, b"native string")

--- a/plone/app/upgrade/v52/tests.py
+++ b/plone/app/upgrade/v52/tests.py
@@ -201,11 +201,10 @@ class SiteLogoTest(unittest.TestCase):
         class ITest(Interface):
             testfield = schema.Bytes()
 
-        # These variations all seem to work on Python 2, but the first two fail on Python 3,
-        # leading to a record.value of None.
-        # migrate_record_from_ascii_to_bytes("testfield", ITest)
+        # These variations all seem to work, so choose the easiest one:
+        migrate_record_from_ascii_to_bytes("testfield", ITest)
         # migrate_record_from_ascii_to_bytes("testfield", ITest, prefix=ITest.__identifier__)
-        migrate_record_from_ascii_to_bytes(record_name, ITest)
+        # migrate_record_from_ascii_to_bytes(record_name, ITest)
         # migrate_record_from_ascii_to_bytes(record_name, ITest, prefix=ITest.__identifier__)
         record = self.registry.records[record_name]
         self.assertIsInstance(record.field, field.Bytes)

--- a/plone/app/upgrade/v52/tests.py
+++ b/plone/app/upgrade/v52/tests.py
@@ -8,6 +8,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IMarkupSchema
 from zope.component import getUtility
 
+import six
 import unittest
 
 
@@ -67,6 +68,89 @@ class Various52Test(unittest.TestCase):
         self.assertTupleEqual(storage.get_full(old), redirect)
 
 
+from plone.registry import field
+from plone.registry import Record
+from plone.app.upgrade.v52.final import migrate_site_logo_from_ascii_to_bytes
+from zope.schema.interfaces import WrongType
+
+
+class SiteLogoTest(unittest.TestCase):
+    """Site logo was ASCII field in 5.1, and is Bytes field in 5.2.
+
+    zope.schema.ASCII inherits from NativeString.
+    With Python 2 this is the same as Bytes, but with Python 3 not:
+    you get a WrongType error when saving the site-controlpanel.
+
+    We have several situations that should result in the fix being applied:
+
+    1. Migration from Plone 5.1 to 5.2 on Python 2.7.
+    2. Migration from Plone 5.2.2 to 5.2.3 (which contains this upgrade step) on Python 2.7.
+    3. Migration from Plone 5.2.2 to 5.2.3 (which contains this upgrade step) on Python 3.
+
+    On Python 3 there is a definite difference between the two types of field.
+    Tricky here may be that we should make sure that the fix is also applied on Python 2,
+    where ASCII and Bytes are still the same.
+
+    Let's duplicate some tests and adapt them slightly to Python 2 and 3,
+    and skip them if the current Python version is different.
+    """
+    layer = PLONE_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.registry = getUtility(IRegistry)
+
+    def test_current_site_logo(self):
+        # Check that we understand the current situation correctly.
+        from plone.app.upgrade.v52.final import migrate_site_logo_from_ascii_to_bytes
+
+        record = self.registry.records['plone.site_logo']
+        self.assertIsInstance(record.field, field.Bytes)
+        self.assertIsNone(record.value)
+        with self.assertRaises(WrongType):
+            record.value = u"abc"
+        record.value = b"ABC"
+        self.assertEqual(record.value, b"ABC")
+        # Migrating does nothing.
+        migrate_site_logo_from_ascii_to_bytes(self.portal)
+        record = self.registry.records['plone.site_logo']
+        self.assertIsInstance(record.field, field.Bytes)
+        self.assertEqual(record.value, b"ABC")
+
+    def test_missing_site_logo_record(self):
+        # Test that the migration adds the record if for some reason it is missing.
+        from plone.app.upgrade.v52.final import migrate_site_logo_from_ascii_to_bytes
+
+        del self.registry.records['plone.site_logo']
+        migrate_site_logo_from_ascii_to_bytes(self.portal)
+        record = self.registry.records['plone.site_logo']
+        self.assertIsInstance(record.field, field.Bytes)
+        self.assertIsNone(record.value)
+
+    @unittest.skipIf(six.PY2, "Only test on Python 3")
+    def test_site_logo_empty(self):
+        del self.registry.records['plone.site_logo']
+        record_51 = Record(field.ASCII())
+        self.registry.records['plone.site_logo'] = record_51
+        # Migrate.
+        migrate_site_logo_from_ascii_to_bytes(self.portal)
+        record = self.registry.records['plone.site_logo']
+        self.assertIsInstance(record.field, field.Bytes)
+        self.assertIsNone(record.value)
+
+    @unittest.skipIf(six.PY2, "Only test on Python 3")
+    def test_site_logo_text(self):
+        del self.registry.records['plone.site_logo']
+        record_51 = Record(field.ASCII())
+        record_51.value = "native string"
+        self.registry.records['plone.site_logo'] = record_51
+        # Migrate.
+        migrate_site_logo_from_ascii_to_bytes(self.portal)
+        record = self.registry.records['plone.site_logo']
+        self.assertIsInstance(record.field, field.Bytes)
+        self.assertEqual(record.value, b"native string")
+
+
 class UpgradePortalTransforms521to522Test(unittest.TestCase):
     layer = PLONE_INTEGRATION_TESTING
 
@@ -106,5 +190,6 @@ def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(UpgradeMemberData51to52Test))
     suite.addTest(unittest.makeSuite(Various52Test))
+    suite.addTest(unittest.makeSuite(SiteLogoTest))
     suite.addTest(unittest.makeSuite(UpgradePortalTransforms521to522Test))
     return suite

--- a/plone/app/upgrade/v52/tests.py
+++ b/plone/app/upgrade/v52/tests.py
@@ -3,6 +3,8 @@ from DateTime import DateTime
 from pkg_resources import get_distribution
 from pkg_resources import parse_version
 from plone.app.testing import PLONE_INTEGRATION_TESTING
+from plone.registry import field
+from plone.registry import Record
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces import IMarkupSchema
@@ -68,12 +70,6 @@ class Various52Test(unittest.TestCase):
         self.assertTupleEqual(storage.get_full(old), redirect)
 
 
-from plone.registry import field
-from plone.registry import Record
-from plone.app.upgrade.v52.final import migrate_site_logo_from_ascii_to_bytes
-from zope.schema.interfaces import WrongType
-
-
 class SiteLogoTest(unittest.TestCase):
     """Site logo was ASCII field in 5.1, and is Bytes field in 5.2.
 
@@ -105,6 +101,7 @@ class SiteLogoTest(unittest.TestCase):
     def test_current_site_logo(self):
         # Check that we understand the current situation correctly.
         from plone.app.upgrade.v52.final import migrate_site_logo_from_ascii_to_bytes
+        from zope.schema.interfaces import WrongType
 
         record = self.registry.records['plone.site_logo']
         self.assertIsInstance(record.field, field.Bytes)
@@ -130,6 +127,8 @@ class SiteLogoTest(unittest.TestCase):
         self.assertIsNone(record.value)
 
     def test_site_logo_empty(self):
+        from plone.app.upgrade.v52.final import migrate_site_logo_from_ascii_to_bytes
+
         del self.registry.records['plone.site_logo']
         record_51 = Record(field.ASCII())
         self.registry.records['plone.site_logo'] = record_51
@@ -140,6 +139,8 @@ class SiteLogoTest(unittest.TestCase):
         self.assertIsNone(record.value)
 
     def test_site_logo_text(self):
+        from plone.app.upgrade.v52.final import migrate_site_logo_from_ascii_to_bytes
+
         del self.registry.records['plone.site_logo']
         record_51 = Record(field.ASCII())
         record_51.value = "native string"

--- a/plone/app/upgrade/v52/tests.py
+++ b/plone/app/upgrade/v52/tests.py
@@ -84,15 +84,17 @@ class SiteLogoTest(unittest.TestCase):
     We have several situations that should result in the fix being applied:
 
     1. Migration from Plone 5.1 to 5.2 on Python 2.7.
-    2. Migration from Plone 5.2.2 to 5.2.3 (which contains this upgrade step) on Python 2.7.
-    3. Migration from Plone 5.2.2 to 5.2.3 (which contains this upgrade step) on Python 3.
+    2. Migration from Plone 5.2.2 on Python 2.7 (where the logo is technically broken, but still works)
+       to 5.2.3 (which contains this upgrade step) on Python 2.7.
+       This is in fact the same as situation 1.
+    3. Migration from Plone 5.2.2 on Python 3 (where the logo is really broken, at least for writing)
+       to 5.2.3 (which contains this upgrade step).
 
     On Python 3 there is a definite difference between the two types of field.
     Tricky here may be that we should make sure that the fix is also applied on Python 2,
     where ASCII and Bytes are still the same.
-
-    Let's duplicate some tests and adapt them slightly to Python 2 and 3,
-    and skip them if the current Python version is different.
+    Ah, no problem after all: zope.schema.ASCII/Bytes may be the same,
+    but plone.registry.fields.ASCII/Bytes are always different.
     """
     layer = PLONE_INTEGRATION_TESTING
 
@@ -127,7 +129,6 @@ class SiteLogoTest(unittest.TestCase):
         self.assertIsInstance(record.field, field.Bytes)
         self.assertIsNone(record.value)
 
-    @unittest.skipIf(six.PY2, "Only test on Python 3")
     def test_site_logo_empty(self):
         del self.registry.records['plone.site_logo']
         record_51 = Record(field.ASCII())
@@ -138,7 +139,6 @@ class SiteLogoTest(unittest.TestCase):
         self.assertIsInstance(record.field, field.Bytes)
         self.assertIsNone(record.value)
 
-    @unittest.skipIf(six.PY2, "Only test on Python 3")
     def test_site_logo_text(self):
         del self.registry.records['plone.site_logo']
         record_51 = Record(field.ASCII())


### PR DESCRIPTION
Otherwise saving the site-controlpanel can fail with a WrongType error
Fixes https://github.com/plone/Products.CMFPlone/issues/3172.

I want to manually test this a bit more, but seems to work.