### PR TITLE
Replaced import of plone.api, which should not be used by core.

### DIFF
--- a/news/241.bugfix
+++ b/news/241.bugfix
@@ -1,0 +1,2 @@
+Replaced import of plone.api, which should not be used by core.
+[maurits]

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -36,11 +36,10 @@ def rebuild_redirections(context):
 
 def move_dotted_to_named_behaviors(context):
     """named behaviors are better then dotted behaviors > let's move them."""
-    from plone import api
     from plone.behavior.registration import lookup_behavior_registration
     from plone.dexterity.interfaces import IDexterityFTI
 
-    ptt = api.portal.get_tool('portal_types')
+    ptt = getToolByName(context, 'portal_types')
 
     ftis = [fti for fti in ptt.objectValues() if IDexterityFTI.providedBy(fti)]
 


### PR DESCRIPTION
Fixes https://github.com/plone/plone.app.upgrade/issues/241