### PR TITLE
Fixed invalid escape sequence.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -2,4 +2,5 @@ Catch deprecation warnings for ``webdav.LockItem.LockItem`` and ``CMFPlone.inter
 The first has been moved to ``OFS.LockItem``, the second to ``plone.i18n.interfaces``.
 In older upgrade code, we should still try the old import first.
 Fixed deprecation warning for zope.site.hooks.
+Fixed invalid escape sequence.
 [maurits]

--- a/plone/app/upgrade/v43/alphas.py
+++ b/plone/app/upgrade/v43/alphas.py
@@ -11,7 +11,7 @@ import re
 
 
 logger = logging.getLogger('plone.app.upgrade')
-num_sort_regex = re.compile('\d+')
+num_sort_regex = re.compile(r'\d+')
 
 
 def reindex_sortable_title(context):


### PR DESCRIPTION
I think this is the last one in 5.2 with Python 3.