### PR TITLE
fix edge case, where relations attributes are missing in catalog

### DIFF
--- a/news/244.bugfix
+++ b/news/244.bugfix
@@ -1,0 +1,2 @@
+Fixes a rare case in v52/betas while migration of relations: Missing attributes on cataloged relations are safely ignored.
+[jensens]

--- a/plone/app/upgrade/v52/betas.py
+++ b/plone/app/upgrade/v52/betas.py
@@ -94,7 +94,13 @@ def remove_interface_indexes_from_relations_catalog():
         except KeyError:
             intids.register(rel)
             added_rel_intids += 1
-        catalog.unindex(rel)
+        try:
+            catalog.unindex(rel)
+        except KeyError:
+            logger.warning("Broken relation ignored due to impossible unindex")
+            # there are rare cases with broken relations where the attributes
+            # are not complete, those can be ignored
+            continue
         try:
             catalog.index(rel)
         except IntIdMissingError:


### PR DESCRIPTION
A rare case from real life: `from_attribute` was missing. Those can be safely ignored.