### PR TITLE
Improved upgrade step for site_logo from ASCII to Bytes.

### DIFF
--- a/news/3172.bugfix
+++ b/news/3172.bugfix
@@ -1,0 +1,4 @@
+Improved upgrade step for site_logo from ASCII to Bytes.
+The previous upgrade was incomplete and could remove the logo when called twice.
+See `comment on issue 3172 <https://github.com/plone/Products.CMFPlone/issues/3172#issuecomment-733085519>`_.
+[maurits]

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -175,9 +175,8 @@
         profile="Products.CMFPlone:plone">
 
         <gs:upgradeStep
-            title="Miscellaneous"
-            description=""
-            handler="..utils.null_upgrade_step"
+            title="Migrate site logo from native string to bytes again"
+            handler=".final.migrate_site_logo_from_ascii_to_bytes"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -191,15 +191,19 @@ def migrate_record_from_ascii_to_bytes(field_name, iface, prefix=None):
         # Unexpected.  Registering the interface fixes this.
         registry.registerInterface(iface, prefix=prefix)
         return
-    if not isinstance(record.field, field.ASCII):
+    # Keep the original value so we can restore it.
+    original_value = record.value
+    if not isinstance(record.field, field.ASCII) and (
+        original_value is None or isinstance(original_value, bytes)
+    ):
         # All is well.
         # Actually, we might as well register the interface again for good measure.
         # For ISiteSchema I have seen a missing site_title field.
         registry.registerInterface(iface, prefix=prefix)
         return
-    # Keep the original value so we can restore it.
-    original_value = record.value
     # Delete the bad record.
+    # Calling registry.registerInterface would clean this up too,
+    # but being explicit seems good here.
     del registry.records[field_name]
     # Make sure the interface is fully registered again.
     # This should recreate the field correctly.

--- a/plone/app/upgrade/v52/tests.py
+++ b/plone/app/upgrade/v52/tests.py
@@ -114,6 +114,7 @@ class SiteLogoTest(unittest.TestCase):
         migrate_site_logo_from_ascii_to_bytes(self.portal)
         record = self.registry.records['plone.site_logo']
         self.assertIsInstance(record.field, field.Bytes)
+        self.assertIsInstance(record.value, bytes)
         self.assertEqual(record.value, b"ABC")
 
     def test_missing_site_logo_record(self):
@@ -149,6 +150,23 @@ class SiteLogoTest(unittest.TestCase):
         migrate_site_logo_from_ascii_to_bytes(self.portal)
         record = self.registry.records['plone.site_logo']
         self.assertIsInstance(record.field, field.Bytes)
+        self.assertIsInstance(record.value, bytes)
+        self.assertEqual(record.value, b"native string")
+
+    @unittest.skipIf(six.PY3, 'Only test on Python 2')
+    def test_site_logo_field_bytes_value_text(self):
+        from plone.app.upgrade.v52.final import migrate_site_logo_from_ascii_to_bytes
+
+        del self.registry.records['plone.site_logo']
+        record_51 = Record(field.Bytes())
+        # This would give a WrongType error on Python 3:
+        record_51.value = "native string"
+        self.registry.records['plone.site_logo'] = record_51
+        # Migrate.
+        migrate_site_logo_from_ascii_to_bytes(self.portal)
+        record = self.registry.records['plone.site_logo']
+        self.assertIsInstance(record.field, field.Bytes)
+        self.assertIsInstance(record.value, bytes)
         self.assertEqual(record.value, b"native string")
 
     def test_migrate_record_from_ascii_to_bytes_with_prefix(self):
@@ -177,6 +195,7 @@ class SiteLogoTest(unittest.TestCase):
         # migrate_record_from_ascii_to_bytes("testfield", ITest, prefix="testing")
         record = self.registry.records["testing.testfield"]
         self.assertIsInstance(record.field, field.Bytes)
+        self.assertIsInstance(record.value, bytes)
         self.assertEqual(record.value, b"native string")
 
     def test_migrate_record_from_ascii_to_bytes_without_prefix(self):
@@ -208,6 +227,7 @@ class SiteLogoTest(unittest.TestCase):
         # migrate_record_from_ascii_to_bytes(record_name, ITest, prefix=ITest.__identifier__)
         record = self.registry.records[record_name]
         self.assertIsInstance(record.field, field.Bytes)
+        self.assertIsInstance(record.value, bytes)
         self.assertEqual(record.value, b"native string")
 
 


### PR DESCRIPTION
The previous upgrade was incomplete and could remove the logo when called twice.
See [comment on issue 3172](https://github.com/plone/Products.CMFPlone/issues/3172#issuecomment-733085519).

Now we explicitly call the improved upgrade step again.  This fixes further fixes any logos that were half fixed in the previous upgrade.