### PR TITLE
Give DX Site Root of existing sites an UUID.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,5 @@
 [settings]
+profile = black
 force_alphabetical_sort = True
 force_single_line = True
 lines_after_imports = 2
-line_length = 200
-not_skip = __init__.py

--- a/news/258.bugfix
+++ b/news/258.bugfix
@@ -1,0 +1,1 @@
+Add an UUID to existing, migrated site roots. [jensens]

--- a/plone/app/upgrade/v60/alphas.py
+++ b/plone/app/upgrade/v60/alphas.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from plone.app.upgrade.utils import loadMigrationProfile
 from plone.dexterity.fti import DexterityFTI
+from plone.uuid.interfaces import ATTRIBUTE_NAME
+from plone.uuid.interfaces import IUUIDGenerator
 from Products.CMFCore.utils import getToolByName
 from ZODB.broken import Broken
+from zope.component import queryUtility
 from zope.component.hooks import getSite
 
 import logging
@@ -97,3 +100,19 @@ def make_site_dx(context):
 
     delattr(portal, "_objects")
     portal._p_changed = True
+
+
+def add_uuid_to_dxsiteroot(context):
+    """Give the Plone Site an UUID."""
+    portal = getSite()
+    if getattr(portal, ATTRIBUTE_NAME, None):
+        # we already have an UUID
+        return
+    generator = queryUtility(IUUIDGenerator)
+    if generator is None:
+        return
+    uuid = generator()
+    if not uuid:
+        return
+    setattr(portal, ATTRIBUTE_NAME, uuid)
+    portal.reindexObject()

--- a/plone/app/upgrade/v60/configure.zcml
+++ b/plone/app/upgrade/v60/configure.zcml
@@ -41,11 +41,12 @@
         profile="Products.CMFPlone:plone">
 
        <gs:upgradeStep
-           title="Miscellaneous"
+           title="Fix UUID for DX Site Root"
            description=""
-           handler="..utils.null_upgrade_step"
+           handler=".alphas.add_uuid_to_dxsiteroot"
            />
 
     </gs:upgradeSteps>
+
 
 </configure>


### PR DESCRIPTION
Seems missing in https://github.com/plone/Products.CMFPlone/issues/2454

Remark: In new sites there is a subscriber in `plone.uuid` adding the attribute. After migration it seems this was not triggered and need manual intervention here. 

related: https://github.com/plone/Products.CMFPlone/issues/3312