### PR TITLE
Reload ISearchSettings to add support for images in liveSearch results.

### DIFF
--- a/news/3489.feature
+++ b/news/3489.feature
@@ -1,0 +1,2 @@
+Reload ISearchSettings to add support for images in liveSearch results.
+[agitator+maurits]

--- a/plone/app/upgrade/v60/profiles/to6004/registry.xml
+++ b/plone/app/upgrade/v60/profiles/to6004/registry.xml
@@ -59,4 +59,7 @@
     <value purge="True"></value>
   </record>
 
+  <records interface="Products.CMFPlone.interfaces.ISearchSchema"
+           prefix="plone" />
+
 </registry>


### PR DESCRIPTION
This is needed by https://github.com/plone/Products.CMFPlone/pull/3489 and friends, otherwise you get an error in a migrated site when viewing the homepage:

```
Traceback (innermost last):
...
  Module zope.viewlet.manager, line 157, in update
  Module zope.viewlet.manager, line 163, in _updateViewlets
  Module plone.app.layout.viewlets.common, line 206, in update
  Module plone.registry.registry, line 78, in forInterface
KeyError: 'Interface `plone.base.interfaces.controlpanel.ISearchSchema` defines a field
 `search_show_images`, for which there is no record.'
```
