### PR TITLE
Add image_scales metadata

### DIFF
--- a/news/3521.feature
+++ b/news/3521.feature
@@ -1,0 +1,2 @@
+Add ``image_scales`` catalog metadata column.
+[maurits]

--- a/news/3521.feature
+++ b/news/3521.feature
@@ -2,4 +2,5 @@ Add ``image_scales`` catalog metadata column.
 Update all brains to get this info.
 Since this takes long on large sites, you can disable this with an environment variable:
 ``export UPDATE_CATALOG_FOR_IMAGE_SCALES=0``
+In that case, you are advised to add the ``image_scales`` column manually to the catalog later.
 [maurits]

--- a/news/3521.feature
+++ b/news/3521.feature
@@ -1,3 +1,5 @@
 Add ``image_scales`` catalog metadata column.
 Update all brains to get this info.
+Since this takes long on large sites, you can disable this with an environment variable:
+``export UPDATE_CATALOG_FOR_IMAGE_SCALES=0``
 [maurits]

--- a/news/3521.feature
+++ b/news/3521.feature
@@ -1,2 +1,3 @@
 Add ``image_scales`` catalog metadata column.
+Update all brains to get this info.
 [maurits]

--- a/plone/app/upgrade/utils.py
+++ b/plone/app/upgrade/utils.py
@@ -1,5 +1,5 @@
 from Acquisition import aq_base
-from Missing import Missing
+from Missing import MV
 from plone.base.utils import get_installer
 from plone.indexer.interfaces import IIndexableObject
 from Products.CMFCore.DirectoryView import _dirreg
@@ -389,10 +389,12 @@ def update_catalog_metadata(context, column=None):
             old_value = record[column_position]
             # see CMFPlone/catalog.zcml
             wrapper = getMultiAdapter((obj, catalog), IIndexableObject)
-            try:
-                new_value = getattr(wrapper, column)
-            except AttributeError:
-                new_value = Missing
+            # See ZCatalog/Catalog.py:recordify
+            new_value = getattr(wrapper, column, MV)
+            if (new_value is not MV and safe_callable(new_value)):
+                new_value = new_value()
+            record.append(attr)
+
             if old_value == new_value:
                 continue
             new_record = list(record)

--- a/plone/app/upgrade/utils.py
+++ b/plone/app/upgrade/utils.py
@@ -8,6 +8,7 @@ from Products.CMFPlone.utils import base_hasattr
 from Products.GenericSetup.interfaces import ISetupTool
 from Products.GenericSetup.registry import _export_step_registry
 from Products.GenericSetup.registry import _import_step_registry
+from Products.PluginIndexes.util import safe_callable
 from Products.ZCatalog.ProgressHandler import ZLogHandler
 from types import ModuleType
 from ZODB.POSException import ConflictError
@@ -393,8 +394,6 @@ def update_catalog_metadata(context, column=None):
             new_value = getattr(wrapper, column, MV)
             if (new_value is not MV and safe_callable(new_value)):
                 new_value = new_value()
-            record.append(attr)
-
             if old_value == new_value:
                 continue
             new_record = list(record)

--- a/plone/app/upgrade/v60/alphas.py
+++ b/plone/app/upgrade/v60/alphas.py
@@ -341,6 +341,11 @@ def update_catalog_for_image_scales(context):
             "UPDATE_CATALOG_FOR_IMAGE_SCALES is false, so not updating catalog."
         )
         return
+    catalog = getToolByName(context, "portal_catalog")
+    column = "image_scales"
+    if column not in catalog.schema():
+        catalog.addColumn(column)
+        logger.info("Added %s column to catalog metadata schema.", column)
     start = time()
     update_catalog_metadata(context)
     end = time()

--- a/plone/app/upgrade/v60/alphas.py
+++ b/plone/app/upgrade/v60/alphas.py
@@ -347,7 +347,7 @@ def update_catalog_for_image_scales(context):
         catalog.addColumn(column)
         logger.info("Added %s column to catalog metadata schema.", column)
     start = time()
-    update_catalog_metadata(context)
+    update_catalog_metadata(context, column=column)
     end = time()
     minutes = (end - start) / 60
     logger.info(

--- a/plone/app/upgrade/v60/configure.zcml
+++ b/plone/app/upgrade/v60/configure.zcml
@@ -115,6 +115,11 @@
            handler=".alphas.upgrade_plone_module_profiles"
            />
 
+       <gs:upgradeStep
+           title="Update catalog brains to add image_scales."
+           handler="plone.app.upgrade.utils.update_catalog_metadata"
+           />
+
     </gs:upgradeSteps>
 
 </configure>

--- a/plone/app/upgrade/v60/configure.zcml
+++ b/plone/app/upgrade/v60/configure.zcml
@@ -117,7 +117,7 @@
 
        <gs:upgradeStep
            title="Update catalog brains to add image_scales."
-           handler="plone.app.upgrade.utils.update_catalog_metadata"
+           handler=".alphas.update_catalog_for_image_scales"
            />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v60/profiles/to6005/catalog.xml
+++ b/plone/app/upgrade/v60/profiles/to6005/catalog.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<object name="portal_catalog" meta_type="Plone Catalog Tool">
- <column value="image_scales"/>
-</object>

--- a/plone/app/upgrade/v60/profiles/to6005/catalog.xml
+++ b/plone/app/upgrade/v60/profiles/to6005/catalog.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_catalog" meta_type="Plone Catalog Tool">
+ <column value="image_scales"/>
+</object>

--- a/plone/app/upgrade/v60/profiles/to6005/registry.xml
+++ b/plone/app/upgrade/v60/profiles/to6005/registry.xml
@@ -6,4 +6,15 @@
   <records interface="plone.base.interfaces.IImagingSchema"
            prefix="plone" />
 
+  <records interface="plone.base.interfaces.controlpanel.IFilterSchema" prefix="plone">
+    <value key="valid_tags" purge="false">
+      <element>picture</element>
+    </value>
+    <value key="custom_attributes" purge="false">
+      <element>loading</element>
+      <element>srcset</element>
+      <element>sizes</element>
+    </value>
+  </records>
+
 </registry>


### PR DESCRIPTION
This upgrade belongs to https://github.com/plone/Products.CMFPlone/pull/3521

- Add `image_scales` column to the catalog.
- Recatalog all brains. I made this a function in `utils.py` as this is useful for add-ons as well. There is nothing specific for this new column.

I updated the html filter settings while I was at it. That belongs to the already merged srcset / picture variants PLIP.