### PR TITLE
[5.2] Add a timezone property to portal memberdata if it is missing

### DIFF
--- a/news/296.fixed
+++ b/news/296.fixed
@@ -1,0 +1,3 @@
+Add a timezone property to portal memberdata if it is missing
+    
+Backports #296 to Plone 5.2

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -265,8 +265,8 @@
         profile="Products.CMFPlone:plone">
 
         <gs:upgradeStep
-            title="Miscellaneous upgrades to Plone 5.2.10"
-            handler="..utils.null_upgrade_step"
+            title="Add a timezone property to portal memberdata if it is missing."
+            handler=".final.add_the_timezone_property"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -267,3 +267,11 @@ def secure_portal_setup_objects(context):
         return
     _recursive_strict_permission(context.snapshots)
     logger.info("Made portal_setup snapshots only available for Manager and Owner.")
+
+
+def add_the_timezone_property(context):
+    """Ensure that the portal_memberdata tool has the timezone property."""
+    portal_memberdata = getToolByName(context, "portal_memberdata")
+    if portal_memberdata.hasProperty("timezone"):
+        return
+    portal_memberdata.manage_addProperty("timezone", "", "string")


### PR DESCRIPTION
Backports #296 to Plone 5.2