### PR TITLE
Add an upgrade step to update the dexterity indexer behavior name

### DIFF
--- a/news/300.bugfix
+++ b/news/300.bugfix
@@ -1,0 +1,1 @@
+Add an upgrade step to fix the dexterity indexer behavior

--- a/plone/app/upgrade/v60/betas.py
+++ b/plone/app/upgrade/v60/betas.py
@@ -81,19 +81,22 @@ def rename_dexteritytextindexer_behavior(context):
     """Rename collective.dexteritytextindexer behavior to plone.textindexer"""
     portal_types = getToolByName(context, "portal_types")
 
-    # Gather the FTIs that have the obsolete behavior
+    # Gather the FTIs that have the obsolete behavior,
+    # it can appear with the name or the interface identifier
+    old_behaviors = {
+        "collective.dexteritytextindexer",
+        "collective.dexteritytextindexer.behavior.IDexterityTextIndexer",
+    }
     ftis_to_fix = (
         fti
         for fti in portal_types.objectValues("Dexterity FTI")
-        if "collective.dexteritytextindexer" in fti.behaviors
+        if set(fti.behaviors) & old_behaviors
     )
 
     for fti in ftis_to_fix:
         # Rename the behavior
         behaviors = [
-            "plone.textindexer"
-            if behavior == "collective.dexteritytextindexer"
-            else behavior
+            "plone.textindexer" if behavior in old_behaviors else behavior
             for behavior in fti.behaviors
         ]
 

--- a/plone/app/upgrade/v60/betas.py
+++ b/plone/app/upgrade/v60/betas.py
@@ -75,3 +75,31 @@ def add_action_icons(context):
                 _set_icon_expr(action, new)
             elif action.icon_expr != new:
                 logger.info("Skipping action %r, it looks customized", action_path)
+
+
+def rename_dexteritytextindexer_behavior(context):
+    """Rename collective.dexteritytextindexer behavior to plone.textindexer"""
+    portal_types = getToolByName(context, "portal_types")
+
+    # Gather the FTIs that have the obsolete behavior
+    ftis_to_fix = (
+        fti
+        for fti in portal_types.objectValues("Dexterity FTI")
+        if "collective.dexteritytextindexer" in fti.behaviors
+    )
+
+    for fti in ftis_to_fix:
+        # Rename the behavior
+        behaviors = [
+            "plone.textindexer"
+            if behavior == "collective.dexteritytextindexer"
+            else behavior
+            for behavior in fti.behaviors
+        ]
+
+        # Ensure we did not have the behavior more than once
+        while behaviors.count("plone.textindexer") > 1:
+            behaviors.remove("plone.textindexer")
+
+        # Set the updated behaviors
+        fti.behaviors = tuple(behaviors)

--- a/plone/app/upgrade/v60/configure.zcml
+++ b/plone/app/upgrade/v60/configure.zcml
@@ -153,6 +153,11 @@
           handler=".betas.add_action_icons"
           />
 
+      <gs:upgradeStep
+          title="Rename the behavior collective.dexteritytextindexer to plone.textindexer"
+          handler=".betas.rename_dexteritytextindexer_behavior"
+          />
+
     </gs:upgradeSteps>
 
 </configure>

--- a/plone/app/upgrade/v60/tests.py
+++ b/plone/app/upgrade/v60/tests.py
@@ -144,7 +144,7 @@ class Various60Test(unittest.TestCase):
         fti = getUtility(IDexterityFTI, name="Document")
 
         original_behaviors = fti.behaviors
-
+        expected_behaviors = original_behaviors + ("plone.textindexer",)
         # If the dexteritytextindexer behavior is not present nothing should change
         rename_dexteritytextindexer_behavior(portal)
         self.assertTupleEqual(fti.behaviors, original_behaviors)
@@ -152,10 +152,17 @@ class Various60Test(unittest.TestCase):
         # If the dexteritytextindexer behavior is present it should be renamed
         fti.behaviors = fti.behaviors + ("collective.dexteritytextindexer",)
         rename_dexteritytextindexer_behavior(portal)
-        self.assertTupleEqual(fti.behaviors, original_behaviors + ("plone.textindexer",))
+        self.assertTupleEqual(fti.behaviors, expected_behaviors)
 
         # If the old and new dexteritytextindexer behaviors are present,
         # we should only have the new one
         fti.behaviors = fti.behaviors + ("collective.dexteritytextindexer",)
         rename_dexteritytextindexer_behavior(portal)
-        self.assertTupleEqual(fti.behaviors, original_behaviors + ("plone.textindexer",))
+        self.assertTupleEqual(fti.behaviors, expected_behaviors)
+
+        # Check that the fix also works with the interface identifier
+        fti.behaviors = original_behaviors + (
+            "collective.dexteritytextindexer.behavior.IDexterityTextIndexer",
+        )
+        rename_dexteritytextindexer_behavior(portal)
+        self.assertTupleEqual(fti.behaviors, expected_behaviors)

--- a/plone/app/upgrade/v60/tests.py
+++ b/plone/app/upgrade/v60/tests.py
@@ -2,6 +2,7 @@ from plone.app.testing import PLONE_INTEGRATION_TESTING
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
+from plone.dexterity.interfaces import IDexterityFTI
 
 import unittest
 
@@ -134,3 +135,27 @@ class Various60Test(unittest.TestCase):
         self.assertEqual(setup.getLastVersionForProfile(profile_id), UNKNOWN)
         upgrade_plone_module_profiles(setup)
         self.assertEqual(setup.getLastVersionForProfile(profile_id), UNKNOWN)
+
+    def test_rename_dexteritytextindexer_behavior(self):
+        from plone.app.upgrade.v60.betas import rename_dexteritytextindexer_behavior
+
+        portal = self.layer["portal"]
+
+        fti = getUtility(IDexterityFTI, name="Document")
+
+        original_behaviors = fti.behaviors
+
+        # If the dexteritytextindexer behavior is not present nothing should change
+        rename_dexteritytextindexer_behavior(portal)
+        self.assertTupleEqual(fti.behaviors, original_behaviors)
+
+        # If the dexteritytextindexer behavior is present it should be renamed
+        fti.behaviors = fti.behaviors + ("collective.dexteritytextindexer",)
+        rename_dexteritytextindexer_behavior(portal)
+        self.assertTupleEqual(fti.behaviors, original_behaviors + ("plone.textindexer",))
+
+        # If the old and new dexteritytextindexer behaviors are present,
+        # we should only have the new one
+        fti.behaviors = fti.behaviors + ("collective.dexteritytextindexer",)
+        rename_dexteritytextindexer_behavior(portal)
+        self.assertTupleEqual(fti.behaviors, original_behaviors + ("plone.textindexer",))


### PR DESCRIPTION
Renames `collective.dexteritytextindexer` to `plone.textindexer`

Fixes #300
Refs. https://github.com/plone/Products.CMFPlone/issues/2780