### PR TITLE
Apply weak caching to GET requests of content with application/json.

### DIFF
--- a/news/73.bugfix
+++ b/news/73.bugfix
@@ -1,0 +1,3 @@
+Apply weak caching to GET requests of content with application/json.
+See `plone.rest issue 73 <https://github.com/plone/plone.rest/issues/73>`_.
+[maurits]

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -281,8 +281,8 @@
         <!-- Plone 5.2.11 -->
 
         <gs:upgradeStep
-            title="Miscellaneous upgrades to Plone 5.2.11"
-            handler="..utils.null_upgrade_step"
+            title="Add GET application/json for content to weak caching."
+            handler=".final.add_get_application_json_to_weak_caching"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -275,3 +275,34 @@ def add_the_timezone_property(context):
     if portal_memberdata.hasProperty("timezone"):
         return
     portal_memberdata.manage_addProperty("timezone", "", "string")
+
+
+def add_get_application_json_to_weak_caching(context):
+    """Add GET application/json for content to weak caching.
+
+    See https://github.com/plone/plone.rest/issues/73#issuecomment-1384298492
+    We want to get this in the templateRulesetMapping setting of the registry:
+
+        <element key="GET_application_json_">plone.content.folderView</element>
+    """
+    registry = getUtility(IRegistry)
+    try:
+        from plone.app.caching.interfaces import IPloneCacheSettings
+    except ImportError:
+        # plone.app.caching is optional.
+        return
+
+    try:
+        settings = registry.forInterface(IPloneCacheSettings)
+    except KeyError:
+        # It is available, but not activated.  Nothing to do.
+        return
+    mapping = settings.templateRulesetMapping
+    key = "GET_application_json_"
+    if key in mapping:
+        # already set, do not change
+        return
+    mapping[key] = "plone.content.folderView"
+    # Note: if we edit templateRulesetMapping, our change will not be persisted,
+    # because it is a simple dict.  We have to set the entire mapping.
+    settings.templateRulesetMapping = mapping


### PR DESCRIPTION
This is the upgrade step belonging to https://github.com/plone/plone.app.caching/pull/111 See https://github.com/plone/plone.rest/issues/73 for the full story.