### PR TITLE
Add two missing upgrades steps to Plone 5.2.10 and 5.2.11.

### DIFF
--- a/news/5211.bugfix
+++ b/news/5211.bugfix
@@ -1,0 +1,2 @@
+Add two missing upgrades steps to Plone 5.2.10 and 5.2.11.
+[maurits]

--- a/plone/app/upgrade/v52/configure.zcml
+++ b/plone/app/upgrade/v52/configure.zcml
@@ -208,4 +208,69 @@
 
     </gs:upgradeSteps>
 
+    <gs:upgradeSteps
+        source="5214"
+        destination="5215"
+        profile="Products.CMFPlone:plone">
+        <!-- Plone 5.2.7 -->
+
+        <gs:upgradeStep
+            title="Miscellaneous"
+            handler="..utils.null_upgrade_step"
+            />
+
+    </gs:upgradeSteps>
+
+    <gs:upgradeSteps
+        source="5215"
+        destination="5216"
+        profile="Products.CMFPlone:plone">
+        <!-- Plone 5.2.8 -->
+
+        <gs:upgradeStep
+            title="Miscellaneous upgrades to Plone 5.2.8"
+            handler="..utils.null_upgrade_step"
+            />
+
+    </gs:upgradeSteps>
+
+    <gs:upgradeSteps
+        source="5216"
+        destination="5217"
+        profile="Products.CMFPlone:plone">
+        <!-- Plone 5.2.9 -->
+
+        <gs:upgradeStep
+            title="Miscellaneous upgrades to Plone 5.2.9"
+            handler="..utils.null_upgrade_step"
+            />
+
+    </gs:upgradeSteps>
+
+    <gs:upgradeSteps
+        source="5217"
+        destination="5218"
+        profile="Products.CMFPlone:plone">
+        <!-- Plone 5.2.10 -->
+
+        <gs:upgradeStep
+            title="Add a timezone property to portal memberdata if it is missing."
+            handler=".final.add_the_timezone_property"
+            />
+
+    </gs:upgradeSteps>
+
+    <gs:upgradeSteps
+        source="5218"
+        destination="5219"
+        profile="Products.CMFPlone:plone">
+        <!-- Plone 5.2.11 -->
+
+        <gs:upgradeStep
+            title="Add GET application/json for content to weak caching."
+            handler=".final.add_get_application_json_to_weak_caching"
+            />
+
+    </gs:upgradeSteps>
+
 </configure>

--- a/plone/app/upgrade/v52/final.py
+++ b/plone/app/upgrade/v52/final.py
@@ -260,3 +260,42 @@ def secure_portal_setup_objects(context):
         return
     _recursive_strict_permission(context.snapshots)
     logger.info("Made portal_setup snapshots only available for Manager and Owner.")
+
+
+def add_the_timezone_property(context):
+    """Ensure that the portal_memberdata tool has the timezone property."""
+    portal_memberdata = getToolByName(context, "portal_memberdata")
+    if portal_memberdata.hasProperty("timezone"):
+        return
+    portal_memberdata.manage_addProperty("timezone", "", "string")
+
+
+def add_get_application_json_to_weak_caching(context):
+    """Add GET application/json for content to weak caching.
+
+    See https://github.com/plone/plone.rest/issues/73#issuecomment-1384298492
+    We want to get this in the templateRulesetMapping setting of the registry:
+
+        <element key="GET_application_json_">plone.content.folderView</element>
+    """
+    registry = getUtility(IRegistry)
+    try:
+        from plone.app.caching.interfaces import IPloneCacheSettings
+    except ImportError:
+        # plone.app.caching is optional.
+        return
+
+    try:
+        settings = registry.forInterface(IPloneCacheSettings)
+    except KeyError:
+        # It is available, but not activated.  Nothing to do.
+        return
+    mapping = settings.templateRulesetMapping
+    key = "GET_application_json_"
+    if key in mapping:
+        # already set, do not change
+        return
+    mapping[key] = "plone.content.folderView"
+    # Note: if we edit templateRulesetMapping, our change will not be persisted,
+    # because it is a simple dict.  We have to set the entire mapping.
+    settings.templateRulesetMapping = mapping


### PR DESCRIPTION
I copied and adapted some code from the plone.app.upgrade branch used in Plone 5.2.