### PR TITLE
Fix plone.app.iterate profiles.

### DIFF
--- a/news/99.bugfix
+++ b/news/99.bugfix
@@ -1,0 +1,2 @@
+Fix plone.app.iterate profiles.
+[maurits]

--- a/plone/app/upgrade/v60/configure.zcml
+++ b/plone/app/upgrade/v60/configure.zcml
@@ -254,6 +254,11 @@
             handler=".final.rolemap_site_admin"
             />
 
+        <gs:upgradeStep
+            title="Fix plone.app.iterate profiles"
+            handler=".final.fix_iterate_profiles"
+            />
+
     </gs:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
See https://github.com/plone/plone.app.iterate/issues/99 There used to be only a `plone.app.iterate:plone.app.iterate` profile. This was kept for backwards compatibility, but copied to a `plone.app.iterate:default` profile, as is usual. We want to remove the old profile definition, but this might give problems when someone still has this installed instead of the default profile.

Later we may want to do something similar with CMFPlacefulWorkflow. See https://github.com/plone/Products.CMFPlacefulWorkflow/issues/38 But this has no default profile yet.