### PR TITLE
Fix TinyMCE problem: Tools and View do not show up in menubar.

### DIFF
--- a/news/3785.bugfix
+++ b/news/3785.bugfix
@@ -1,0 +1,3 @@
+Fix TinyMCE problem: Tools and View do not show up in menubar.
+The menubar contained "toolsview" instead.
+[maurits]

--- a/plone/app/upgrade/v60/configure.zcml
+++ b/plone/app/upgrade/v60/configure.zcml
@@ -283,8 +283,8 @@
         <!-- Plone 6.0.5 -->
 
         <gs:upgradeStep
-            title="Miscellaneous"
-            handler="..utils.null_upgrade_step"
+            title="Fix TinyMCE menubar"
+            handler=".final.fix_tinymce_menubar"
             />
 
     </gs:upgradeSteps>

--- a/plone/app/upgrade/v60/final.py
+++ b/plone/app/upgrade/v60/final.py
@@ -1,5 +1,7 @@
 from AccessControl.Permission import Permission
 from plone.base.utils import get_installer
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 from zope.component.hooks import getSite
 
 import logging
@@ -117,3 +119,22 @@ def fix_iterate_profiles(context):
     else:
         # Now seems a good time to run any upgrade steps.
         installer.upgrade_product(product)
+
+
+def fix_tinymce_menubar(context):
+    """Fix menubar with 'toolsview' instead of 'tools' and 'view'.
+
+    See https://github.com/plone/Products.CMFPlone/issues/3785
+    """
+    registry = getUtility(IRegistry)
+    record = registry.records.get("plone.menubar")
+    if record is None:
+        return
+    value = record.value
+    if "toolsview" not in value:
+        return
+    index = value.index("toolsview")
+    value.pop(index)
+    value.insert(index, "view")
+    value.insert(index, "tools")
+    record.value = value


### PR DESCRIPTION
The menubar contained "toolsview" instead.
Fixes https://github.com/plone/Products.CMFPlone/issues/3785