### PR TITLE
Remove Archetypes modifiers from portal_modifier early

### DIFF
--- a/news/6003.bugfix
+++ b/news/6003.bugfix
@@ -1,0 +1,3 @@
+Remove Archetypes modifiers from portal_modifier early in Plone 6.0 alpha.
+CMFEditions already tried to do this, but this might fail in a corner case.
+[maurits]

--- a/plone/app/upgrade/v60/configure.zcml
+++ b/plone/app/upgrade/v60/configure.zcml
@@ -64,6 +64,11 @@
         profile="Products.CMFPlone:plone">
 
        <gs:upgradeStep
+           title="Remove broken modifiers"
+           handler=".alphas.remove_broken_modifiers"
+           />
+
+       <gs:upgradeStep
            title="Fix unicode properties"
            handler=".alphas.fix_unicode_properties"
            />


### PR DESCRIPTION
CMFEditions already tried to do this, but this might fail in a corner case. See report at https://community.plone.org/t/upgrading-migrating-from-5-2-6-to-6-0-5-fails/17577 This new upgrade step basically uses the [code from the comment there](https://community.plone.org/t/upgrading-migrating-from-5-2-6-to-6-0-5-fails/17577/6?u=mauritsvanrees).