### PR TITLE
Fix upgrading `plone.app.iterate` to specific version.

### DIFF
--- a/news/99.bugfix
+++ b/news/99.bugfix
@@ -1,0 +1,3 @@
+Fix upgrading `plone.app.iterate` to specific version.
+In Plone 6.1 the deprecated GS profile with id `plone.app.iterate` has been removed, and only `default` remains, as is usual.
+[maurits]

--- a/plone/app/upgrade/v60/alphas.py
+++ b/plone/app/upgrade/v60/alphas.py
@@ -463,7 +463,12 @@ def upgrade_plone_module_profiles(context):
         ("plone.app.dexterity:default", "2007"),
         ("plone.app.discussion:default", "2000"),
         ("plone.app.event:default", "15"),
+        # Let's try both possible iterate profiles.
+        # Only one of them will have been marked as installed,
+        # but we don't know which one.  This will be fixed in
+        # v60/final.py in fix_iterate_profiles.
         ("plone.app.iterate:plone.app.iterate", "121"),
+        ("plone.app.iterate:default", "121"),
         ("plone.app.multilingual:default", "1000"),
         ("plone.app.querystring:default", "14"),
         ("plone.app.theming:default", "1002"),


### PR DESCRIPTION
In Plone 6.1 the deprecated GS profile with id `plone.app.iterate` has been removed, and only `default` remains, as is usual.

I will run Jenkins on 6.0 with only this PR.

And I will run Jenkins on 6.1 with this PR plus https://github.com/plone/plone.app.iterate/pull/125
