### PR TITLE
6.1: Remove the portal_properties tool completely.

### DIFF
--- a/news/125.bugfix
+++ b/news/125.bugfix
@@ -1,0 +1,3 @@
+6.1: Remove the portal_properties tool completely.
+This tool is deprecated, and we said we would remove it in 6.1.
+[maurits]

--- a/plone/app/upgrade/v61/configure.zcml
+++ b/plone/app/upgrade/v61/configure.zcml
@@ -54,15 +54,14 @@
       destination="6103"
       >
     <!-- Plone 6.1.0a4 -->
-    <gs:upgradeStep
-        title="Miscellaneous"
-        handler="..utils.null_upgrade_step"
-        />
-
     <gs:upgradeDepends
       title="Run to6103 upgrade profile."
       import_profile="plone.app.upgrade.v61:to6103"
       />
+    <gs:upgradeStep
+        title="Remove the portal_properties tool."
+        handler=".final.remove_portal_properties_tool"
+        />
   </gs:upgradeSteps>
 
 </configure>

--- a/plone/app/upgrade/v61/final.py
+++ b/plone/app/upgrade/v61/final.py
@@ -1,0 +1,23 @@
+from Products.CMFCore.utils import getToolByName
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def remove_portal_properties_tool(context):
+    """Remove the portal_properties tool.
+
+    Core Plone has moved to the configuration registry in Plone 5.0.
+    Add-ons may have still used it, but we announced we would remove
+    it in Plone 6.1.
+    """
+    portal = getToolByName(context, "portal_url").getPortalObject()
+    tool = getattr(portal, "portal_properties", None)
+    if tool is None:
+        return
+    # portal._delObject("portal_properties") would give:
+    # AttributeError: 'PropertiesTool' object has no attribute '__of__'
+    portal._delOb("portal_properties")
+    logger.info("Removed portal_properties tool.")


### PR DESCRIPTION
This tool is deprecated, and we said we would remove it in 6.1.
To be tested together with https://github.com/plone/Products.CMFPlone/pull/3990 on 6.1.
