### PR TITLE
6.1: Cleanup plone.app.discussion settings when package is missing

### DIFF
--- a/news/211.bugfix
+++ b/news/211.bugfix
@@ -1,0 +1,4 @@
+6.1: Cleanup ``plone.app.discussion`` settings when the package is not available.
+If the site contains comments, we throw an error and stop the upgrade.
+The advice then is to add the ``plone.app.discussion`` package.
+[maurits]

--- a/plone/app/upgrade/v61/configure.zcml
+++ b/plone/app/upgrade/v61/configure.zcml
@@ -71,8 +71,8 @@
       >
     <!-- Plone 6.1.0a5 -->
     <gs:upgradeStep
-        title="Miscellaneous"
-        handler="..utils.null_upgrade_step"
+        title="Maybe get rid of plone.app.discussion"
+        handler=".final.maybe_cleanup_discussion"
         />
   </gs:upgradeSteps>
 

--- a/plone/app/upgrade/v61/final.py
+++ b/plone/app/upgrade/v61/final.py
@@ -1,4 +1,12 @@
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
+from Acquisition import aq_parent
+from importlib.metadata import distribution
+from importlib.metadata import PackageNotFoundError
+from plone.app.upgrade.utils import loadMigrationProfile
+from plone.browserlayer.utils import unregister_layer
 from Products.CMFCore.utils import getToolByName
+from zope.component import getSiteManager
 
 import logging
 
@@ -21,3 +29,77 @@ def remove_portal_properties_tool(context):
     # AttributeError: 'PropertiesTool' object has no attribute '__of__'
     portal._delOb("portal_properties")
     logger.info("Removed portal_properties tool.")
+
+
+def maybe_cleanup_discussion(context):
+    """Cleanup some left-overs from plone.app.discussion.
+
+    But only do this when the package is not available.
+    In Plone 6.1, the package was made into a core add-on.
+    Meaning: it no longer gets pulled in by Products.CMFPlone,
+    but only by the Plone package.
+    """
+    # First check if the GS profile was installed.
+    profile_id = "plone.app.discussion:default"
+    if context.getLastVersionForProfile(profile_id) == "unknown":
+        logger.info("%s was not installed, nothing to do.", profile_id)
+        return
+    try:
+        distribution("plone.app.discussion")
+        logger.info("The plone.app.discussion package is available, so we do nothing.")
+        return
+    except PackageNotFoundError:
+        logger.info("plone.app.discussion package not found, will cleanup.")
+
+    # First check if there are any actual discussion items in the site.
+    catalog = getToolByName(context, "portal_catalog")
+    brains = catalog.unrestrictedSearchResults(portal_type="Discussion Item")
+    total = len(brains)
+    if total:
+        raise ValueError(
+            f"{total} Discussion Items (comments) were found in the site, but "
+            "plone.app.discussion is missing.\nThis package is optional since "
+            "Plone 6.1.\nPlease add plone.app.discussion to your Plone installation "
+            "if you want to keep using them."
+        )
+
+    # First apply a profile.  This is mostly a copy of the uninstall profile
+    # of plone.app.discussion.
+    loadMigrationProfile(context, "profile-plone.app.upgrade.v61:uninstall-discussion")
+
+    # The registry keys were registered via the IDiscussionSettings interface
+    # which no longer exists, so we remove them one by one.
+    registry = getUtility(IRegistry)
+    records = registry.records
+    to_remove = [
+        key
+        for key in records.keys()
+        if "plone.app.discussion.interfaces.IDiscussionSettings" in key
+    ]
+    for key in to_remove:
+        del records[key]
+    logger.info("Removed all IDiscussionSettings registry records.")
+
+    # Gather the FTIs that have the plone.allowdiscussion behavior.
+    # It can appear with the name or the interface identifier.
+    portal_types = getToolByName(context, "portal_types")
+    old_behaviors = {
+        "plone.allowdiscussion",
+        "plone.app.dexterity.behaviors.discussion.IAllowDiscussion",
+    }
+    ftis_to_fix = (
+        fti
+        for fti in portal_types.objectValues("Dexterity FTI")
+        if set(fti.behaviors) & old_behaviors
+    )
+    for fti in ftis_to_fix:
+        # Remove the behavior.  Remember this is a tuple.
+        behaviors = [
+            behavior for behavior in fti.behaviors if behavior not in old_behaviors
+        ]
+        # Set the updated behaviors
+        fti.behaviors = tuple(behaviors)
+        logger.info("Removed plone.allowdiscussion behavior from %s", fti)
+
+    # Mark GS profile as not installed/activated.
+    context.unsetLastVersionForProfile(profile_id)

--- a/plone/app/upgrade/v61/profiles.zcml
+++ b/plone/app/upgrade/v61/profiles.zcml
@@ -11,4 +11,13 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <!-- This is a copy of plone.app.discussion/profiles/uninstall. -->
+  <genericsetup:registerProfile
+      name="uninstall-discussion"
+      title="Uninstall plone.app.discussion"
+      directory="profiles/uninstall-discussion"
+      for="plone.base.interfaces.IMigratingPloneSiteRoot"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      />
+
 </configure>

--- a/plone/app/upgrade/v61/profiles/uninstall-discussion/actions.xml
+++ b/plone/app/upgrade/v61/profiles/uninstall-discussion/actions.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        name="portal_actions"
+>
+  <object meta_type="CMF Action Category"
+          name="user"
+  >
+    <object meta_type="CMF Action"
+            name="review-comments"
+            remove="true"
+    />
+  </object>
+</object>

--- a/plone/app/upgrade/v61/profiles/uninstall-discussion/browserlayer.xml
+++ b/plone/app/upgrade/v61/profiles/uninstall-discussion/browserlayer.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layers>
+  <layer name="plone.app.discussion"
+         remove="true"
+  />
+</layers>

--- a/plone/app/upgrade/v61/profiles/uninstall-discussion/catalog.xml
+++ b/plone/app/upgrade/v61/profiles/uninstall-discussion/catalog.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object name="portal_catalog">
+
+  <index meta_type="FieldIndex"
+         name="total_comments"
+         remove="true"
+  />
+  <index meta_type="KeywordIndex"
+         name="commentators"
+         remove="true"
+  />
+  <column remove="true"
+          value="total_comments"
+  />
+  <column remove="true"
+          value="last_comment_date"
+  />
+  <column remove="true"
+          value="commentators"
+  />
+  <column remove="true"
+          value="in_response_to"
+  />
+  <column remove="true"
+          value="author_name"
+  />
+
+</object>

--- a/plone/app/upgrade/v61/profiles/uninstall-discussion/controlpanel.xml
+++ b/plone/app/upgrade/v61/profiles/uninstall-discussion/controlpanel.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        name="portal_controlpanel"
+        purge="False"
+        i18n:domain="plone"
+>
+
+  <configlet action_id="discussion"
+             appId="plone.app.discussion"
+             category="plone-content"
+             remove="true"
+  />
+
+</object>

--- a/plone/app/upgrade/v61/profiles/uninstall-discussion/registry.xml
+++ b/plone/app/upgrade/v61/profiles/uninstall-discussion/registry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry>
+  <!-- This would give ModuleNotFoundError: No module named 'plone.app.discussion'
+       So we do this in Python code in maybe_cleanup_discussion. -->
+  <!-- <records interface="plone.app.discussion.interfaces.IDiscussionSettings"
+           remove="true"
+  /> -->
+</registry>

--- a/plone/app/upgrade/v61/profiles/uninstall-discussion/types.xml
+++ b/plone/app/upgrade/v61/profiles/uninstall-discussion/types.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object meta_type="CMF Types Tool"
+        name="portal_types"
+>
+  <object meta_type="Factory-based Type Information"
+          name="Discussion Item"
+	  remove="True"
+  />
+</object>

--- a/plone/app/upgrade/v61/profiles/uninstall-discussion/workflows.xml
+++ b/plone/app/upgrade/v61/profiles/uninstall-discussion/workflows.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<object meta_type="Plone Workflow Tool"
+        name="portal_workflow"
+>
+  <object meta_type="Workflow"
+          name="comment_review_workflow"
+          remove="True"
+  />
+  <object meta_type="Workflow"
+          name="comment_one_state_workflow"
+          remove="True"
+  />
+</object>


### PR DESCRIPTION
If the site contains comments, we throw an error and stop the upgrade. The advice then is to add the `plone.app.discussion` package.

This is part of https://github.com/plone/Products.CMFPlone/issues/3958

I tried offering to remove existing comments, when the user has explicitly set an environment variable.  But this gets tricky.  In the catalog you can search for Discussion Items, but when you do `brain.getObject()` this fails with an AttributeError because the path contains `++conversation++default` and this is only defined when `plone.app.discussion` is available.  We could get all brains, check if they have `total_comments` more than zero, get the object, and then `del __annotations__["plone.app.discussion"]`.  But then we would need to unindex the actual comments as well, so it starts sounding hairy.  Let someone implement this who actually needs it.  That would be the case for a site where there were comments in 6.0, but in 6.1 they no longer want the comments.  But that really is a corner case.

What I did to test this PR:

* In Plone 5.2 on Python 3 create one default Plone Site and one Plone Site with comments enabled, and a few comments actually added.
* Copy the database to the coredev 6.1 buildout.
* Run the 6.1 buildout with `bin/buildout -c plips/plip-padiscussion-addon.cfg`. Do `git pull` first, I have updated the plip file.
* Run `bin/instance-cmfplone fg`.  This starts the 6.1 site with Products.CMFPlone (so without `plone.app.discussion`), but with `plone.app.upgrade` and `plone.app.caching` as extras, so you can test the upgrade.
* The `@@plone-upgrade` of the first Plone Site should work fine and cleanup everything.
* The upgrade of the second site, so the one with comments, will explicitly fail because we see comments and refuse to continue.  Best here is to add `plone.app.discussion` to the packages.  You see this advice in the browser:

```
ValueError: 3 Discussion Items (comments) were found in the site, but plone.app.discussion is missing.
This package is optional since Plone 6.1.
Please add plone.app.discussion to your Plone installation if you want to keep using them.
```

In fact, when upgrading from Plone 5.2 on a site that has comments, you already get into a traceback before you reach the new upgrade step:

```
2024-08-13 18:34:42,957 INFO    [plone.app.upgrade:403][waitress-3] Added image_scales column to catalog metadata schema.
2024-08-13 18:34:42,957 INFO    [plone.app.upgrade:368][waitress-3] Updating metadata.
2024-08-13 18:34:42,957 INFO    [ProgressHandler:73][waitress-3] Process started (10 objects to go)
2024-08-13 18:34:42,962 ERROR   [plone.app.upgrade:295][waitress-3] Upgrade aborted. Error:
Traceback (most recent call last):
  File "/Users/maurits/shared-eggs/cp311/Zope-5.10-py3.11.egg/OFS/Traversable.py", line 236, in unrestrictedTraverse
    next = namespaceLookup(
           ^^^^^^^^^^^^^^^^
  File "/Users/maurits/shared-eggs/cp311/zope.traversing-5.0-py3.11.egg/zope/traversing/namespace.py", line 162, in namespaceLookup
    raise LocationError(object, "++{}++{}".format(ns, name))
zope.location.interfaces.LocationError: (<Document at /Plone2/page>, '++conversation++default')
```

I also tried first migrating the 5.2 site to 6.0.  Then the above traceback does not happen.

Also the [`PicklingError` from this comment](https://github.com/plone/plone.app.discussion/pull/211#issuecomment-2168439010) only happens when you migrate from 5.2 directly to 6.1.  On a site that is first migrated to 6.0 it goes better.