### PR TITLE
Drop pkg_resources usage

### DIFF
--- a/news/4126.bugfix
+++ b/news/4126.bugfix
@@ -1,0 +1,1 @@
+Replace `pkg_resources` with `importlib.metadata`/`packaging` @gforcada

--- a/plone/app/upgrade/__init__.py
+++ b/plone/app/upgrade/__init__.py
@@ -1,11 +1,11 @@
+from importlib.metadata import distribution
+from importlib.metadata import PackageNotFoundError
 from plone.app.upgrade.utils import alias_module
-
-import pkg_resources
 
 
 try:
-    pkg_resources.get_distribution("Products.CMFQuickInstallerTool")
-except pkg_resources.DistributionNotFound:
+    distribution("Products.CMFQuickInstallerTool")
+except PackageNotFoundError:
     # The alias module helps when migrating to Plone 6.0.0a1.
     # Remove when we no longer support upgrading from Plone 5.2.
     from . import bbb_qi

--- a/plone/app/upgrade/utils.py
+++ b/plone/app/upgrade/utils.py
@@ -1,4 +1,5 @@
 from Acquisition import aq_base
+from importlib.metadata import distribution
 from Missing import MV
 from plone.base.utils import base_hasattr
 from plone.base.utils import get_installer
@@ -16,25 +17,30 @@ from zope.component import ComponentLookupError
 from zope.component import getMultiAdapter
 
 import logging
-import pkg_resources
 import sys
 import transaction
+import warnings
 
 
 _marker = []
 
 logger = logging.getLogger("plone.app.upgrade")
 
-plone_version = pkg_resources.get_distribution("Products.CMFPlone").version
+plone_version = distribution("Products.CMFPlone").version
 
 
 def version_match(target):
-    """Given, our versioning scheme is always major.minorANYTHING, where major
-    and minor are single-digit numbers, we can compare versions as follows.
-    pkg_resources.parse_version is not compatible with our versioning scheme
-    (like '5.0b1') and also not compatible with the semver.org proposal
-    (requires '5.0-beta1').
+    """Does a target version have the same major and minor version as CMFPlone?
+
+    Given, our versioning scheme is always major.minor.ANYTHING, where major
+    and minor are single-digit numbers, we can compare versions as follows,
+    without worrying about strictly following semantic versioning.
     """
+    warnings.warn(
+        "This method is no longer used by plone.app.upgrade. "
+        "You can use packaging.version.parse instead. Will be removed in Plone 7",
+        DeprecationWarning,
+    )
     # MAJOR.MINOR
     return (target[0], target[2]) == (plone_version[0], plone_version[2])
 

--- a/plone/app/upgrade/v52/tests.py
+++ b/plone/app/upgrade/v52/tests.py
@@ -1,6 +1,6 @@
 from DateTime import DateTime
-from pkg_resources import get_distribution
-from pkg_resources import parse_version
+from importlib.metadata import distribution
+from packaging import version
 from plone.app.testing import PLONE_INTEGRATION_TESTING
 from plone.registry import field
 from plone.registry import Record
@@ -248,8 +248,8 @@ class UpgradePortalTransforms521to522Test(unittest.TestCase):
 
 def test_suite():
     # Skip these tests on Plone < 5.2a1
-    plone_version = get_distribution("Products.CMFPlone").version
-    if not parse_version(plone_version) >= parse_version("5.2a1"):
+    plone_version = distribution("Products.CMFPlone").version
+    if not version.parse(plone_version) >= version.parse("5.2a1"):
         return unittest.TestSuite()
 
     return unittest.TestSuite((

--- a/plone/app/upgrade/v52/tests.py
+++ b/plone/app/upgrade/v52/tests.py
@@ -1,6 +1,4 @@
 from DateTime import DateTime
-from importlib.metadata import distribution
-from packaging import version
 from plone.app.testing import PLONE_INTEGRATION_TESTING
 from plone.registry import field
 from plone.registry import Record
@@ -247,11 +245,6 @@ class UpgradePortalTransforms521to522Test(unittest.TestCase):
 
 
 def test_suite():
-    # Skip these tests on Plone < 5.2a1
-    plone_version = distribution("Products.CMFPlone").version
-    if not version.parse(plone_version) >= version.parse("5.2a1"):
-        return unittest.TestSuite()
-
     return unittest.TestSuite((
         unittest.defaultTestLoader.loadTestsFromTestCase(UpgradeMemberData51to52Test),
         unittest.defaultTestLoader.loadTestsFromTestCase(Various52Test),


### PR DESCRIPTION
See https://github.com/plone/Products.CMFPlone/issues/4126

This also remove some dead code (see the first commit), if that has to be kept around still, we need to drop that commit only.