### PR TITLE
Harden condition of external editor action.

### DIFF
--- a/news/4179.bugfix
+++ b/news/4179.bugfix
@@ -1,0 +1,2 @@
+Harden condition of external editor action to not fail when the ``externalEditorEnabled`` script is not available.
+[maurits]

--- a/plone/app/upgrade/v61/configure.zcml
+++ b/plone/app/upgrade/v61/configure.zcml
@@ -139,7 +139,12 @@
 
     <gs:upgradeStep
         title="convert TinyMCE menubar registry entry"
-        handler="..v61.final.upgrade_registry_tinymce_menubar"
+        handler=".final.upgrade_registry_tinymce_menubar"
+        />
+
+    <gs:upgradeStep
+        title="Make the condition for the external editor action safer."
+        handler=".final.make_external_editor_action_condition_safer"
         />
 
   </gs:upgradeSteps>

--- a/plone/app/upgrade/v62/configure.zcml
+++ b/plone/app/upgrade/v62/configure.zcml
@@ -11,9 +11,10 @@
       >
     <!-- Plone 6.2.0a1 -->
     <gs:upgradeStep
-        title="Miscellaneous"
-        handler="..utils.null_upgrade_step"
+        title="Make the condition for the external editor action safer."
+        handler="..v61.final.make_external_editor_action_condition_safer"
         />
+
   </gs:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
Do not fail when the ``externalEditorEnabled`` script is not available. This is the upgrade step belonging to https://github.com/plone/Products.CMFPlone/pull/4179.