### PR TITLE
Do not "fix" menubar value of ITinyMCESchema if it is already a string.

### DIFF
--- a/news/340.bugfix
+++ b/news/340.bugfix
@@ -1,0 +1,2 @@
+Do not "fix" menubar value of ITinyMCESchema if it is already a string.
+[maurits]

--- a/plone/app/upgrade/v61/final.py
+++ b/plone/app/upgrade/v61/final.py
@@ -112,8 +112,13 @@ def upgrade_registry_tinymce_menubar(context):
 
     registry = getUtility(IRegistry)
 
+    value = registry.records["plone.menubar"].value
+    if isinstance(value, str):
+        # no fix needed
+        return
+
     # convert list to string
-    menubar = " ".join(registry.records["plone.menubar"].value)
+    menubar = " ".join(value)
 
     # delete the record
     del registry.records["plone.menubar"]


### PR DESCRIPTION
For me the value got converted to `e d i t   t a b l e   f o r m a t   t o o l s   v i e w   i n s e r t`.
See https://github.com/plone/plone.app.upgrade/pull/341#issuecomment-2991940663

I think I will just merge and release after waiting a few minutes.
