### PR TITLE
Remove ``IPropertiesTool`` components.

### DIFF
--- a/news/338.bugfix
+++ b/news/338.bugfix
@@ -1,0 +1,3 @@
+Remove ``IPropertiesTool`` components.
+These were left over after the removal of the ``portal_properties`` tool in Plone 6.1.
+[maurits]

--- a/news/338.feature
+++ b/news/338.feature
@@ -1,0 +1,3 @@
+Add ``utils.remove_utility`` helper function.
+Code taken over from ``collective.migrationhelpers``.
+[maurits, pbauer]

--- a/plone/app/upgrade/v61/configure.zcml
+++ b/plone/app/upgrade/v61/configure.zcml
@@ -62,6 +62,10 @@
         title="Remove the portal_properties tool."
         handler=".final.remove_portal_properties_tool"
         />
+    <gs:upgradeStep
+        title="Remove IPropertiesTool components."
+        handler=".final.remove_ipropertiestool_components"
+        />
   </gs:upgradeSteps>
 
   <gs:upgradeSteps
@@ -151,8 +155,8 @@
       >
     <!-- Plone 6.1.3 -->
     <gs:upgradeStep
-        title="Miscellaneous"
-        handler="..utils.null_upgrade_step"
+        title="Remove IPropertiesTool components."
+        handler=".final.remove_ipropertiestool_components"
         />
   </gs:upgradeSteps>
 

--- a/plone/app/upgrade/v61/final.py
+++ b/plone/app/upgrade/v61/final.py
@@ -1,10 +1,12 @@
 from importlib.metadata import distribution
 from importlib.metadata import PackageNotFoundError
 from plone.app.upgrade.utils import loadMigrationProfile
+from plone.app.upgrade.utils import remove_utility
 from plone.base.interfaces.controlpanel import ITinyMCESchema
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
+from zope.component.hooks import getSiteManager
 
 import logging
 
@@ -27,6 +29,19 @@ def remove_portal_properties_tool(context):
     # AttributeError: 'PropertiesTool' object has no attribute '__of__'
     portal._delOb("portal_properties")
     logger.info("Removed portal_properties tool.")
+
+
+def remove_ipropertiestool_components(context):
+    """Remove IPropertiesTool components.
+
+    After running `remove_portal_properties_tool` from above,
+    some related components may still linger.
+    See https://github.com/plone/plone.app.upgrade/issues/338
+    """
+    from Products.CMFCore.interfaces import IPropertiesTool
+
+    remove_utility(IPropertiesTool)
+    logger.info("Removed IPropertiesTool components.")
 
 
 def maybe_cleanup_discussion(context):


### PR DESCRIPTION
These were left over after the removal of the ``portal_properties`` tool in Plone 6.1.

This uses a new ``utils.remove_utility`` helper function. Code taken over from ``collective.migrationhelpers``.  In that package, the code was added by @pbauer with additions by me.

This fixes issue #338.