### PR TITLE
Fix out-of-memory problem in 6005 upgrade steps.

### DIFF
--- a/news/368.bugfix.rst
+++ b/news/368.bugfix.rst
@@ -1,2 +1,2 @@
-Fix possible out-of-memory problem in ``utils.update_catalog_metadata` by releasing memory early.
+Fix possible out-of-memory problem in ``utils.update_catalog_metadata`` by releasing memory early.
 [thet, jensens]

--- a/news/368.bugfix.rst
+++ b/news/368.bugfix.rst
@@ -1,16 +1,2 @@
-Fix out-of-memory problem in 6005 upgrade steps.
-
-When running the "Update catalog brains to add image_scales."
-(`plone.app.upgrade.v60.alphas.update_catalog_for_image_scales`) upgrade step
-from the 6005 upgradeSteps this does a reindex catalog on all objects with
-image_scales. That runs `plone.app.upgrade.utils.update_catalog_metadata` and
-this might run out of memory.
-
-This PR calls `_p_deactivate` on each object in `update_catalog_metadata` which
-sets them in ghost state and that should release the object's memory.
-
-That doesn't let the process consume memory until the server's limit.
-
-Fixes: #368
-
+Fix possible out-of-memory problem in ``utils.update_catalog_metadata` by releasing memory early.
 [thet, jensens]

--- a/news/368.bugfix.rst
+++ b/news/368.bugfix.rst
@@ -1,0 +1,16 @@
+Fix out-of-memory problem in 6005 upgrade steps.
+
+When running the "Update catalog brains to add image_scales."
+(`plone.app.upgrade.v60.alphas.update_catalog_for_image_scales`) upgrade step
+from the 6005 upgradeSteps this does a reindex catalog on all objects with
+image_scales. That runs `plone.app.upgrade.utils.update_catalog_metadata` and
+this might run out of memory.
+
+This PR calls `_p_deactivate` on each object in `update_catalog_metadata` which
+sets them in ghost state and that should release the object's memory.
+
+That doesn't let the process consume memory until the server's limit.
+
+Fixes: #368
+
+[thet, jensens]

--- a/src/plone/app/upgrade/utils.py
+++ b/src/plone/app/upgrade/utils.py
@@ -434,6 +434,7 @@ def update_catalog_metadata(context, column=None):
             raise
         except Exception:
             pass
+        obj._p_deactivate()
     pghandler.finish()
     logger.info("Updated metadata of all brains.")
 


### PR DESCRIPTION
When running the "Update catalog brains to add image_scales." (``plone.app.upgrade.v60.alphas.update_catalog_for_image_scales``) upgrade step from the 6005 upgradeSteps this does a reindex catalog on all objects with image_scales. That runs ``plone.app.upgrade.utils.update_catalog_metadata`` and this might run out of memory.

This PR calls ``_p_deactivate`` on each object in ``update_catalog_metadata`` which sets them in ghost state and that should release the object's memory.

That doesn't let the process consume memory until the server's limit.

Fixes: #368

- [ ] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [ ] I verified there aren't any other open pull requests for the same change.
- [ ] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [ ] I successfully ran code quality checks on my changes locally.
- [ ] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [ ] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

