### PR TITLE
Add a commit_threshold for utils.update_catalog_metadata.

### DIFF
--- a/news/+commit_threshold.feature.rst
+++ b/news/+commit_threshold.feature.rst
@@ -1,0 +1,6 @@
+Add a commit_threshold for utils.update_catalog_metadata.
+
+Per default it commits every 1000 objects. This should free up some memory for
+long running catalog reindexes.
+
+@thet

--- a/src/plone/app/upgrade/utils.py
+++ b/src/plone/app/upgrade/utils.py
@@ -368,7 +368,7 @@ def updateIconsInBrains(context, typesToUpdate=None):
     logger.info("Updated `getIcon` metadata.")
 
 
-def update_catalog_metadata(context, column=None):
+def update_catalog_metadata(context, column=None, commit_threshold=1000):
     """Update catalog metadata for all brains."""
     catalog = getToolByName(context, "portal_catalog")
     logger.info("Updating metadata.")
@@ -434,7 +434,10 @@ def update_catalog_metadata(context, column=None):
             raise
         except Exception:
             pass
+
         obj._p_deactivate()
+        if index % commit_threshold == 0:
+            transaction.commit()
     pghandler.finish()
     logger.info("Updated metadata of all brains.")
 


### PR DESCRIPTION
Per default it commits every 1000 objects. This should free up some memory for long running catalog reindexes.